### PR TITLE
Added functionality to publish events to AWS SNS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ bin
 .classpath
 .settings
 .project
+.idea
 *.iml
 *.ipr
 *.iws

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,11 @@
             <name>Maxime Charron</name>
             <email>charron.maxime97@gmail.com</email>
         </developer>
+        <developer>
+            <id>alexgandy</id>
+            <name>Alex Gandy</name>
+            <email>alexgandy@gmail.com</email>
+        </developer>
     </developers>
 
     <licenses>
@@ -55,7 +60,22 @@
         <powermock.version>1.6.5</powermock.version>
         <jenkins.version>1.645</jenkins.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-bom</artifactId>
+                <version>1.11.22</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sns</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.mashape.unirest</groupId>
             <artifactId>unirest-java</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.6</version>
+            <version>4.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
@@ -5,7 +5,6 @@ import hudson.Extension;
 import hudson.util.FormValidation;
 import jenkins.model.GlobalConfiguration;
 import net.sf.json.JSONObject;
-import org.apache.commons.logging.Log;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import com.amazonaws.regions.RegionUtils;
@@ -27,7 +26,7 @@ public class StatisticsConfiguration extends GlobalConfiguration {
     private String awsRegion;
     private String awsAccessKey;
     private String awsSecretKey;
-    private String snsArn;
+    private String snsTopicArn;
 
     private Boolean queueInfo;
     private Boolean buildInfo;
@@ -186,10 +185,10 @@ public class StatisticsConfiguration extends GlobalConfiguration {
         save();
     }
 
-    public String getSnsArn() { return snsArn; }
+    public String getSnsTopicArn() { return snsTopicArn; }
 
-    public void setSnsArn(String snsArn) {
-        this.snsArn = snsArn;
+    public void setSnsTopicArn(String snsTopicArn) {
+        this.snsTopicArn = snsTopicArn;
         save();
     }
 
@@ -324,10 +323,10 @@ public class StatisticsConfiguration extends GlobalConfiguration {
         return FormValidation.ok();
     }
 
-    public FormValidation doCheckSnsArn(
-            @QueryParameter("snsArn") final String snsArn) {
+    public FormValidation doCheckSnsTopicArn(
+            @QueryParameter("snsTopicArn") final String snsTopicArn) {
         if (shouldPublishToAwsSnsQueue) {
-            if (snsArn == null || snsArn.isEmpty()) {
+            if (snsTopicArn == null || snsTopicArn.isEmpty()) {
                 return FormValidation.error("SNS ARN required. ");
             }
         }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
@@ -1,11 +1,14 @@
 package org.jenkins.plugins.statistics.gatherer;
 
+import com.amazonaws.regions.Region;
 import hudson.Extension;
 import hudson.util.FormValidation;
 import jenkins.model.GlobalConfiguration;
 import net.sf.json.JSONObject;
+import org.apache.commons.logging.Log;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+import com.amazonaws.regions.RegionUtils;
 
 /**
  * Created by hthakkallapally on 6/25/2015.
@@ -21,12 +24,18 @@ public class StatisticsConfiguration extends GlobalConfiguration {
     private String projectUrl;
     private String scmCheckoutUrl;
     private String buildStepUrl;
+    private String awsRegion;
+    private String awsAccessKey;
+    private String awsSecretKey;
+    private String snsArn;
 
     private Boolean queueInfo;
     private Boolean buildInfo;
     private Boolean projectInfo;
     private Boolean scmCheckoutInfo;
     private Boolean buildStepInfo;
+    private Boolean shouldSendApiHttpRequests;
+    private Boolean shouldPublishToAwsSnsQueue;
 
     public StatisticsConfiguration() {
         load();
@@ -91,7 +100,6 @@ public class StatisticsConfiguration extends GlobalConfiguration {
         save();
     }
 
-
     public void setQueueUrl(String queueUrl) {
         this.queueUrl = queueUrl;
         save();
@@ -154,6 +162,48 @@ public class StatisticsConfiguration extends GlobalConfiguration {
 
     public void setScmCheckoutUrl(String scmCheckoutUrl) {
         this.scmCheckoutUrl = scmCheckoutUrl;
+        save();
+    }
+
+    public String getAwsRegion() { return awsRegion; }
+
+    public void setAwsRegion(String awsRegion) {
+        this.awsRegion = awsRegion;
+        save();
+    }
+
+    public String getAwsAccessKey() { return awsAccessKey; }
+
+    public void setAwsAccessKey(String awsAccessKey) {
+        this.awsAccessKey = awsAccessKey;
+        save();
+    }
+
+    public String getAwsSecretKey() { return awsSecretKey; }
+
+    public void setAwsSecretKey(String awsSecretKey) {
+        this.awsSecretKey = awsSecretKey;
+        save();
+    }
+
+    public String getSnsArn() { return snsArn; }
+
+    public void setSnsArn(String snsArn) {
+        this.snsArn = snsArn;
+        save();
+    }
+
+    public Boolean getShouldSendApiHttpRequests() { return shouldSendApiHttpRequests; }
+
+    public void setShouldSendApiHttpRequests(Boolean shouldSendApiHttpRequests) {
+        this.shouldSendApiHttpRequests = shouldSendApiHttpRequests;
+        save();
+    }
+
+    public Boolean getShouldPublishToAwsSnsQueue() { return shouldPublishToAwsSnsQueue; }
+
+    public void setShouldPublishToAwsSnsQueue(Boolean shouldPublishToAwsSnsQueue) {
+        this.shouldPublishToAwsSnsQueue = shouldPublishToAwsSnsQueue;
         save();
     }
 
@@ -242,7 +292,6 @@ public class StatisticsConfiguration extends GlobalConfiguration {
         return FormValidation.ok();
     }
 
-
     public FormValidation doCheckBuildStepInfo(
             @QueryParameter("buildStepInfo") final Boolean buildStepInfo) {
         if (buildStepInfo == null) {
@@ -256,6 +305,55 @@ public class StatisticsConfiguration extends GlobalConfiguration {
         if (scmCheckoutInfo == null) {
             return FormValidation.error("Provide valid CcmCheckoutInfo. ");
         }
+        return FormValidation.ok();
+    }
+
+    public FormValidation doCheckAwsRegion(
+        @QueryParameter("awsRegion") final String awsRegion) {
+        if (shouldPublishToAwsSnsQueue) {
+            if (awsRegion == null) {
+                return FormValidation.error("AWS Region required. ");
+            }
+
+            Region r = RegionUtils.getRegion(awsRegion);
+            if (r == null || !r.isServiceSupported("sns")) {
+                return FormValidation.error("Please enter a valid SNS AWS region. ");
+            }
+        }
+
+        return FormValidation.ok();
+    }
+
+    public FormValidation doCheckSnsArn(
+            @QueryParameter("snsArn") final String snsArn) {
+        if (shouldPublishToAwsSnsQueue) {
+            if (snsArn == null || snsArn.isEmpty()) {
+                return FormValidation.error("SNS ARN required. ");
+            }
+        }
+
+        return FormValidation.ok();
+    }
+
+    public FormValidation doCheckAwsAccessKey(
+            @QueryParameter("awsAccessKey") final String awsAccessKey) {
+        if (shouldPublishToAwsSnsQueue) {
+            if (awsAccessKey == null || awsAccessKey.isEmpty()) {
+                return FormValidation.error("AWS Access Key required. ");
+            }
+        }
+
+        return FormValidation.ok();
+    }
+
+    public FormValidation doCheckAwsSecretKey(
+            @QueryParameter("awsSecretKey") final String awsSecretKey) {
+        if (shouldPublishToAwsSnsQueue) {
+            if (awsSecretKey == null || awsSecretKey.isEmpty()) {
+                return FormValidation.error("AWS Secret Key required. ");
+            }
+        }
+
         return FormValidation.ok();
     }
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListener.java
@@ -8,6 +8,7 @@ import hudson.tasks.BuildStep;
 import org.jenkins.plugins.statistics.gatherer.model.step.BuildStepStats;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
 import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
+import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
 
 import java.util.Date;
 
@@ -27,6 +28,7 @@ public class BuildStepStatsListener extends BuildStepListener {
             buildStepStats.setEndTime(new Date());
             buildStepStats.setStartTime(new Date(0));
             RestClientUtil.postToService(getRestUrl(), buildStepStats);
+            SnsClientUtil.publishToSns(buildStepStats);
         }
     }
 
@@ -40,6 +42,7 @@ public class BuildStepStatsListener extends BuildStepListener {
             buildStepStats.setStartTime(new Date());
             buildStepStats.setEndTime(new Date(0));
             RestClientUtil.postToService(getRestUrl(), buildStepStats);
+            SnsClientUtil.publishToSns(buildStepStats);
         }
     }
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
@@ -10,6 +10,7 @@ import org.jenkins.plugins.statistics.gatherer.model.job.JobStats;
 import org.jenkins.plugins.statistics.gatherer.util.Constants;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
 import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
+import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
 
 import java.io.IOException;
 import java.util.Date;
@@ -40,6 +41,7 @@ public class ItemStatsListener extends ItemListener {
                 ciJob.setStatus(Constants.ACTIVE);
                 setConfig(project, ciJob);
                 RestClientUtil.postToService(getRestUrl(), ciJob);
+                SnsClientUtil.publishToSns(ciJob);
             } catch (Exception e) {
                 logException(item, e);
             }
@@ -107,6 +109,7 @@ public class ItemStatsListener extends ItemListener {
                 ciJob.setStatus(project.isDisabled() ? Constants.DISABLED : Constants.ACTIVE);
                 setConfig(project, ciJob);
                 RestClientUtil.postToService(getRestUrl(), ciJob);
+                SnsClientUtil.publishToSns(ciJob);
             } catch (Exception e) {
                 logException(item, e);
             }
@@ -125,6 +128,7 @@ public class ItemStatsListener extends ItemListener {
                 ciJob.setUpdatedDate(new Date());
                 ciJob.setStatus(Constants.DELETED);
                 RestClientUtil.postToService(getRestUrl(), ciJob);
+                SnsClientUtil.publishToSns(ciJob);
             } catch (Exception e) {
                 logException(item, e);
             }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/QueueStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/QueueStatsListener.java
@@ -9,10 +9,7 @@ import hudson.triggers.TimerTrigger;
 import jenkins.model.Jenkins;
 import org.jenkins.plugins.statistics.gatherer.model.queue.QueueCause;
 import org.jenkins.plugins.statistics.gatherer.model.queue.QueueStats;
-import org.jenkins.plugins.statistics.gatherer.util.Constants;
-import org.jenkins.plugins.statistics.gatherer.util.JenkinsCauses;
-import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
-import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
+import org.jenkins.plugins.statistics.gatherer.util.*;
 
 import java.util.Date;
 import java.util.List;
@@ -75,6 +72,7 @@ public class QueueStatsListener extends QueueListener {
                     addExitQueueCause("waiting", waitingItem, queue);
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
+                SnsClientUtil.publishToSns(queue);
             } catch (Exception e) {
                 logExceptionWaiting(waitingItem, e);
             }
@@ -105,6 +103,7 @@ public class QueueStatsListener extends QueueListener {
                     addEntryQueueCause("blocked", blockedItem, queue);
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
+                SnsClientUtil.publishToSns(queue);
             } catch (Exception e) {
                 logExceptionBlocked(blockedItem, e);
             }
@@ -127,6 +126,7 @@ public class QueueStatsListener extends QueueListener {
                 }
 
                 RestClientUtil.postToService(getRestUrl(), queue);
+                SnsClientUtil.publishToSns(queue);
             } catch (Exception e) {
                 logExceptionBlocked(blockedItem, e);
             }
@@ -142,6 +142,7 @@ public class QueueStatsListener extends QueueListener {
                     addEntryQueueCause("buildable", buildableItem, queue);
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
+                SnsClientUtil.publishToSns(queue);
             } catch (Exception e) {
                 logExceptionLeave(buildableItem, e);
             }
@@ -157,6 +158,7 @@ public class QueueStatsListener extends QueueListener {
                     addExitQueueCause("buildable", buildableItem, queue);
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
+                SnsClientUtil.publishToSns(queue);
             } catch (Exception e) {
                 logExceptionLeave(buildableItem, e);
             }
@@ -212,6 +214,7 @@ public class QueueStatsListener extends QueueListener {
                 queue.setDuration(System.currentTimeMillis() - leftItem.getInQueueSince());
                 queue.setContextId(leftItem.outcome.hashCode());
                 RestClientUtil.postToService(getRestUrl(), queue);
+                SnsClientUtil.publishToSns(queue);
             } catch (Exception e) {
                 logExceptionLeft(leftItem, e);
             }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
@@ -67,6 +67,7 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
                 addParameters(run, build);
                 addSlaveInfo(run, build, listener);
                 RestClientUtil.postToService(getRestUrl(), build);
+                SnsClientUtil.publishToSns(build);
                 LOGGER.log(Level.INFO, "Started build and its status is : " + buildResult +
                         " and start time is : " + run.getTimestamp().getTime());
             } catch (Exception e) {
@@ -230,6 +231,7 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
                 build.setEndTime(Calendar.getInstance().getTime());
                 addBuildFailureCauses(build);
                 RestClientUtil.postToService(getRestUrl(), build);
+                SnsClientUtil.publishToSns(build);
                 LOGGER.log(Level.INFO, run.getParent().getName() + " build is completed " +
                         "its status is : " + buildResult +
                         " at time : " + new Date());
@@ -275,6 +277,7 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
             scmCheckoutInfo.setBuildUrl(build.getUrl());
             scmCheckoutInfo.setEndTime(new Date(0));
             RestClientUtil.postToService(getScmCheckoutUrl(), scmCheckoutInfo);
+            SnsClientUtil.publishToSns(scmCheckoutInfo);
         }
         return super.setUpEnvironment(build, launcher, listener);
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListener.java
@@ -11,6 +11,7 @@ import hudson.scm.SCMRevisionState;
 import org.jenkins.plugins.statistics.gatherer.model.scm.ScmCheckoutInfo;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
 import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
+import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
 
 import java.io.File;
 import java.util.Calendar;
@@ -33,6 +34,7 @@ public class ScmStatsListener extends SCMListener{
             scmCheckoutInfo.setStartTime(new Date(0));
             scmCheckoutInfo.setEndTime(Calendar.getInstance().getTime());
             RestClientUtil.postToService(getUrl(), scmCheckoutInfo);
+            SnsClientUtil.publishToSns(scmCheckoutInfo);
         }
     }
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
@@ -111,6 +111,42 @@ public class PropertyLoader {
         return endPoint == null ? "" : endPoint;
     }
 
+    public static String getAwsRegion() {
+        String awsRegion = StatisticsConfiguration.get().getAwsRegion();
+        if (awsRegion != null && !awsRegion.isEmpty()) {
+            return awsRegion;
+        }
+        awsRegion = getEnvironmentProperty("statistics.endpoint.awsRegion");
+        return awsRegion == null ? "" : awsRegion;
+    }
+
+    public static String getAwsAccessKey() {
+        String awsAccessKey = StatisticsConfiguration.get().getAwsAccessKey();
+        if (awsAccessKey != null && !awsAccessKey.isEmpty()) {
+            return awsAccessKey;
+        }
+        awsAccessKey = getEnvironmentProperty("statistics.endpoint.awsAccessKey");
+        return awsAccessKey == null ? "" : awsAccessKey;
+    }
+
+    public static String getAwsSecretKey() {
+        String awsSecretKey = StatisticsConfiguration.get().getAwsSecretKey();
+        if (awsSecretKey != null && !awsSecretKey.isEmpty()) {
+            return awsSecretKey;
+        }
+        awsSecretKey = getEnvironmentProperty("statistics.endpoint.awsSecretKey");
+        return awsSecretKey == null ? "" : awsSecretKey;
+    }
+
+    public static String getSnsArn() {
+        String snsArn = StatisticsConfiguration.get().getSnsArn();
+        if (snsArn != null && !snsArn.isEmpty()) {
+            return snsArn;
+        }
+        snsArn = getEnvironmentProperty("statistics.endpoint.snsArn");
+        return snsArn == null ? "" : snsArn;
+    }
+
     public static Boolean getQueueInfo() {
         Boolean queueInfo = StatisticsConfiguration.get().getQueueInfo();
         if (queueInfo != null) {
@@ -154,5 +190,23 @@ public class PropertyLoader {
         }
         String scmCheckoutInfoEnv = getEnvironmentProperty("statistics.endpoint.scmCheckoutInfo");
         return "true".equals(scmCheckoutInfoEnv);
+    }
+
+    public static Boolean getShouldSendApiHttpRequests() {
+        Boolean shouldSendApiHttpRequests = StatisticsConfiguration.get().getShouldSendApiHttpRequests();
+        if (shouldSendApiHttpRequests != null) {
+            return shouldSendApiHttpRequests;
+        }
+        String shouldSendApiHttpRequestsInfoEnv = getEnvironmentProperty("statistics.endpoint.shouldSendApiHttpRequests");
+        return "true".equals(shouldSendApiHttpRequestsInfoEnv);
+    }
+
+    public static Boolean getShouldPublishToAwsSnsQueue() {
+        Boolean shouldPublishToAwsSnsQueue = StatisticsConfiguration.get().getShouldPublishToAwsSnsQueue();
+        if (shouldPublishToAwsSnsQueue != null) {
+            return shouldPublishToAwsSnsQueue;
+        }
+        String shouldPublishToAwsSnsQueueEnv = getEnvironmentProperty("statistics.endpoint.shouldPublishToAwsSnsQueue");
+        return "true".equals(shouldPublishToAwsSnsQueueEnv);
     }
 }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
@@ -138,13 +138,13 @@ public class PropertyLoader {
         return awsSecretKey == null ? "" : awsSecretKey;
     }
 
-    public static String getSnsArn() {
-        String snsArn = StatisticsConfiguration.get().getSnsArn();
-        if (snsArn != null && !snsArn.isEmpty()) {
-            return snsArn;
+    public static String getSnsTopicArn() {
+        String snsTopicArn = StatisticsConfiguration.get().getSnsTopicArn();
+        if (snsTopicArn != null && !snsTopicArn.isEmpty()) {
+            return snsTopicArn;
         }
-        snsArn = getEnvironmentProperty("statistics.endpoint.snsArn");
-        return snsArn == null ? "" : snsArn;
+        snsTopicArn = getEnvironmentProperty("statistics.endpoint.snsTopicArn");
+        return snsTopicArn == null ? "" : snsTopicArn;
     }
 
     public static Boolean getQueueInfo() {

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/RestClientUtil.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/RestClientUtil.java
@@ -12,8 +12,7 @@ import java.util.logging.Logger;
 
 public class RestClientUtil {
 
-    private static final Logger LOGGER = Logger.getLogger(
-            RestClientUtil.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(RestClientUtil.class.getName());
     public static final String APPLICATION_JSON = "application/json";
     public static final String ACCEPT = "accept";
     public static final String CONTENT_TYPE = "Content-Type";
@@ -23,27 +22,29 @@ public class RestClientUtil {
     }
 
     public static void postToService(final String url, Object object) {
-        String jsonToPost = JSONUtil.convertToJson(object);
-        Unirest.post(url)
-                .header(ACCEPT, APPLICATION_JSON)
-                .header(CONTENT_TYPE, APPLICATION_JSON)
-                .body(jsonToPost)
-                .asJsonAsync(new Callback<JsonNode>() {
+        if (PropertyLoader.getShouldSendApiHttpRequests()) {
+            String jsonToPost = JSONUtil.convertToJson(object);
+            Unirest.post(url)
+                    .header(ACCEPT, APPLICATION_JSON)
+                    .header(CONTENT_TYPE, APPLICATION_JSON)
+                    .body(jsonToPost)
+                    .asJsonAsync(new Callback<JsonNode>() {
 
-                    public void failed(UnirestException e) {
-                        LOGGER.log(Level.WARNING, "The request for url " + url + " has failed.", e);
-                    }
+                        public void failed(UnirestException e) {
+                            LOGGER.log(Level.WARNING, "The request for url " + url + " has failed.", e);
+                        }
 
-                    public void completed(HttpResponse<JsonNode> response) {
-                        int responseCode = response.getStatus();
-                        LOGGER.log(Level.INFO, "The request for url " + url + " completed with status " + responseCode);
-                    }
+                        public void completed(HttpResponse<JsonNode> response) {
+                            int responseCode = response.getStatus();
+                            LOGGER.log(Level.INFO, "The request for url " + url + " completed with status " + responseCode);
+                        }
 
-                    public void cancelled() {
-                        LOGGER.log(Level.INFO, "The request for url " + url + " has been cancelled");
-                    }
+                        public void cancelled() {
+                            LOGGER.log(Level.INFO, "The request for url " + url + " has been cancelled");
+                        }
 
-                });
+                    });
+        }
     }
 
     public static JSONObject getJson(final String url) {

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/SnsClientUtil.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/SnsClientUtil.java
@@ -1,0 +1,62 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.handlers.AsyncHandler;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.RegionUtils;
+import com.amazonaws.services.sns.AmazonSNSAsyncClient;
+import com.amazonaws.services.sns.model.PublishRequest;
+import com.amazonaws.services.sns.model.PublishResult;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Created by alexgandy on 1/12/17.
+ */
+public class SnsClientUtil {
+
+    private static final Logger LOGGER = Logger.getLogger(AmazonSNSAsyncClient.class.getName());
+    private static AmazonSNSAsyncClient snsClient;
+
+    public static AmazonSNSAsyncClient getSnsClient() {
+        if (snsClient == null) {
+            BasicAWSCredentials awsCredentials = new BasicAWSCredentials(PropertyLoader.getAwsAccessKey(), PropertyLoader.getAwsSecretKey());
+            snsClient = new AmazonSNSAsyncClient(awsCredentials);
+
+            Region snsRegion = RegionUtils.getRegion(PropertyLoader.getAwsRegion());
+            snsClient.setRegion(snsRegion);
+        }
+
+        return snsClient;
+    }
+
+    public static void publishToSns(Object object) {
+        if (PropertyLoader.getShouldPublishToAwsSnsQueue()) {
+            String jsonToPublish = JSONUtil.convertToJson(object);
+
+            PublishRequest pr = new PublishRequest();
+            String snsTopicArn = PropertyLoader.getSnsTopicArn();
+
+            if (snsTopicArn == null || snsTopicArn.isEmpty()) {
+                LOGGER.log(Level.WARNING, "Missing required SNS Topic ARN");
+                return;
+            }
+
+            pr.setTopicArn(PropertyLoader.getSnsTopicArn());
+            pr.setMessage(jsonToPublish);
+
+            AmazonSNSAsyncClient client = getSnsClient();
+            client.publishAsync(pr, new AsyncHandler<PublishRequest, PublishResult>() {
+                @Override
+                public void onError(Exception e) {
+                    LOGGER.log(Level.WARNING, e.getMessage(), e);
+                }
+
+                @Override
+                public void onSuccess(PublishRequest request, PublishResult publishResult) {
+                    LOGGER.log(Level.INFO, "Message ID: " + publishResult.getMessageId() + " successfully published");
+                }
+            });
+        }
+    }
+}

--- a/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
+++ b/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
@@ -34,4 +34,31 @@ f.section(title:_("Statistics Gatherer")) {
     f.entry(title:_("Send Scm Checkout Info"), field:"scmCheckoutInfo") {
         f.checkbox(default: true)
     }
+
+    f.advanced(title: _("Advanced Settings")) {
+
+        f.entry(title:_("Publish to Amazon SNS Queue"), field:"shouldPublishToAwsSnsQueue") {
+            f.checkbox(default: instance.shouldPublishToAwsSnsQueue == null ? false : instance.shouldPublishToAwsSnsQueue.equals(true));
+        }
+
+        f.entry(title:_("AWS Access Key"), field:"awsAccessKey") {
+            f.textbox()
+        }
+
+        f.entry(title:_("AWS Secret Key"), field:"awsSecretKey") {
+            f.textbox()
+        }
+
+        f.entry(title:_("AWS Region"), field:"awsRegion") {
+            f.textbox()
+        }
+
+        f.entry(title:_("SNS ARN"), field:"snsArn") {
+            f.textbox()
+        }
+
+        f.entry(title:_("Disable API HTTP requests? (Only use SNS?)"), field:"shouldSendApiHttpRequests") {
+            f.checkbox(default: instance.shouldSendApiHttpRequests == null ? false : instance.shouldSendApiHttpRequests.equals(true));
+        }
+    }
 }

--- a/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
+++ b/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
@@ -49,11 +49,11 @@ f.section(title:_("Statistics Gatherer")) {
             f.textbox()
         }
 
-        f.entry(title:_("AWS Region"), field:"awsRegion") {
+        f.entry(title:_("SNS Topic ARN"), field:"snsTopicArn") {
             f.textbox()
         }
 
-        f.entry(title:_("SNS ARN"), field:"snsArn") {
+        f.entry(title:_("AWS Region"), field:"awsRegion") {
             f.textbox()
         }
 

--- a/src/main/resources/statistics.properties
+++ b/src/main/resources/statistics.properties
@@ -8,3 +8,6 @@ statistics.endpoint.buildInfo=true
 statistics.endpoint.projectInfo=true
 statistics.endpoint.buildStepInfo=true
 statistics.endpoint.scmCheckoutInfo=true
+statistics.endpoint.awsRegion=us-east-1
+statistics.endpoint.shouldSendApiHttpRequests=true
+statistics.endpoint.shouldPublishToAwsSnsQueue=false

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListenerTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListenerTest.java
@@ -12,6 +12,7 @@ import org.jenkins.plugins.statistics.gatherer.model.scm.ScmCheckoutInfo;
 import org.jenkins.plugins.statistics.gatherer.model.step.BuildStepStats;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
 import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
+import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
Added SnsClientUtil, so that events can be published to SNS topics. Also added the ability to disable HTTP posts of events, in case you only want to use SNS.

![New Admin Fields](https://www.dropbox.com/s/dudu0rjcge7o28o/Screenshot%202017-01-12%2016.46.03.png?dl=1)

(The SNS options are hidden under an "Advanced" button...expanded for this screenshot)