### PR TITLE
Remove Job Type Filters

### DIFF
--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
@@ -45,9 +45,6 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
     public void onStarted(Run<?, ?> run, TaskListener listener) {
         if (PropertyLoader.getBuildInfo()) {
             try {
-                if (!(run instanceof AbstractBuild)) {
-                    return;
-                }
                 final String buildResult = run.getResult() == null ?
                         "INPROGRESS" : run.getResult().toString();
                 BuildStats build = new BuildStats();
@@ -214,10 +211,6 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
     public void onFinalized(final Run<?, ?> run) {
         if (PropertyLoader.getBuildInfo()) {
             try {
-                if (!(run instanceof AbstractBuild)) {
-                    return;
-                }
-
                 final String buildResult = run.getResult() == null ?
                         Constants.UNKNOWN : run.getResult().toString();
                 BuildStats build = new BuildStats();


### PR DESCRIPTION
Pipeline jobs were not emitting build events due to a check of whether a triggering job was an AbstractBuild or not. Removing this check allows all tested job types (freestyle, pipeline/workflow,
and matrix) to post build events.