### PR TITLE
Add ScmInfo on build completion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-test-harness</artifactId>
+            <version>1.644</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
@@ -222,6 +222,7 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
                 build.setBuildUrl(run.getUrl());
                 build.setDuration(run.getDuration());
                 build.setEndTime(Calendar.getInstance().getTime());
+                addSCMInfo(run, SoutTaskListener.INSTANCE, build);
                 addBuildFailureCauses(build);
                 RestClientUtil.postToService(getRestUrl(), build);
                 SnsClientUtil.publishToSns(build);

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/SoutTaskListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/SoutTaskListener.java
@@ -1,0 +1,49 @@
+package org.jenkins.plugins.statistics.gatherer.listeners;
+
+import hudson.console.ConsoleNote;
+import hudson.model.TaskListener;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
+public class SoutTaskListener implements TaskListener {
+    private static PrintWriter soutWriter = new PrintWriter(System.out);
+
+    public static final SoutTaskListener INSTANCE = new SoutTaskListener();
+
+    @Override
+    public PrintStream getLogger() {
+        return System.out;
+    }
+
+    @Override
+    public void annotate(ConsoleNote ann) throws IOException {
+
+    }
+
+    @Override
+    public void hyperlink(String url, String text) throws IOException {
+
+    }
+
+    @Override
+    public PrintWriter error(String msg) {
+        return soutWriter;
+    }
+
+    @Override
+    public PrintWriter error(String format, Object... args) {
+        return soutWriter;
+    }
+
+    @Override
+    public PrintWriter fatalError(String msg) {
+        return soutWriter;
+    }
+
+    @Override
+    public PrintWriter fatalError(String format, Object... args) {
+        return soutWriter;
+    }
+}

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListenerTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListenerTest.java
@@ -1,0 +1,97 @@
+package org.jenkins.plugins.statistics.gatherer.listeners;
+
+import hudson.model.Build;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.TaskListener;
+import hudson.model.queue.QueueTaskFuture;
+import hudson.tasks.Shell;
+import jenkins.model.Jenkins;
+import org.jenkins.plugins.statistics.gatherer.model.build.BuildStats;
+import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
+import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.ArgumentCaptor;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.isNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import static org.hamcrest.CoreMatchers.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PropertyLoader.class, RestClientUtil.class})
+@PowerMockIgnore({"javax.crypto.*"})
+public class RunStatsListenerTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private RunStatsListener listener;
+    private TaskListener soutListener = new SoutTaskListener();
+
+    @Before
+    public void setup() {
+        listener = new RunStatsListener();
+        mockStatic(PropertyLoader.class);
+        mockStatic(RestClientUtil.class);
+    }
+
+    @Test
+    public void givenRunWithBuildInfoTrue_whenStarted_thenPostTwice() throws Exception {
+        when(PropertyLoader.getBuildInfo()).thenReturn(true);
+
+        Build<?, ?> build = triggerNewBuild().get();
+
+        verifyStatic(times(2));
+        ArgumentCaptor<BuildStats> captor =
+                ArgumentCaptor.forClass(BuildStats.class);
+        RestClientUtil.postToService(anyString(), captor.capture());
+        BuildStats buildStats = captor.getAllValues().get(0);
+
+        assertThat(buildStats.getResult(), is(equalTo("INPROGRESS")));
+        assertBuildInfoEqualsTo(buildStats, build);
+    }
+
+    @Test
+    public void givenRunWithBuildInfoTrue_whenCompleted_thenPost() throws Exception {
+        when(PropertyLoader.getBuildInfo()).thenReturn(true);
+
+        Build<?, ?> build = triggerNewBuild().get();
+
+        verifyStatic(times(2));
+        ArgumentCaptor<BuildStats> captor =
+                ArgumentCaptor.forClass(BuildStats.class);
+        RestClientUtil.postToService(anyString(), captor.capture());
+        BuildStats buildStats = captor.getAllValues().get(1);
+
+        assertThat(buildStats.getResult(), is(equalTo("SUCCESS")));
+        assertBuildInfoEqualsTo(buildStats, build);
+    }
+
+    private void assertBuildInfoEqualsTo(BuildStats buildStats, Build<?, ?> build) {
+        assertThat(buildStats.getBuildUrl(), is(build.getUrl()));
+        assertThat(buildStats.getStartTime(), is(notNullValue()));
+        assertThat(buildStats.getBuildCause(), is(notNullValue()));
+        assertThat(buildStats.getFullJobName(), is(build.getParent().getFullName()));
+        assertThat(buildStats.getJobName(), is(build.getParent().getName()));
+        assertThat(buildStats.getNumber(), is(build.getNumber()));
+    }
+
+    private QueueTaskFuture<FreeStyleBuild> triggerNewBuild() throws IOException {
+        FreeStyleProject project = j.createFreeStyleProject();
+        project.getBuildersList().add(new Shell("echo hello"));
+        return project.scheduleBuild2(0);
+    }
+}


### PR DESCRIPTION
The build completion event can get the SCM Info from the
node environment variables and thus having a complete
record of what impacted which commit.