### PR TITLE
Upgrade to jenkins 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -57,8 +57,9 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <powermock.version>1.6.5</powermock.version>
-        <jenkins.version>1.645</jenkins.version>
+        <jenkins.version>2.60.1</jenkins.version>
+        <java.level>8</java.level>
+        <powermock.version>1.7.4</powermock.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -112,13 +113,13 @@
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-war</artifactId>
             <type>war</type>
-            <version>1.650</version>
+            <version>${jenkins.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-test-harness</artifactId>
-            <version>1.644</version>
+            <version>${jenkins-test-harness.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -162,7 +163,6 @@
                 <!-- version specified in grandparent pom -->
                 <extensions>true</extensions>
                 <configuration>
-                    <showDeprecation>true</showDeprecation>
                     <disabledTestInjection>true</disabledTestInjection>
                 </configuration>
             </plugin>


### PR DESCRIPTION
To allow major improvements and the adoption of Java 8, upgrade
    the overall pom.xml version to 2.x to indicate a breaking point
    and fully leverage new Jenkins 2.x plugins features.