### PR TITLE
Allow logback nats appender transport

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.7.4</version>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+        </dependency>
 
         <!-- Test dependancies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -108,9 +108,10 @@
             <version>2.7.4</version>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>logback-nats-appender</artifactId>
+            <version>0.2.2</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,12 @@
             <artifactId>logback-classic</artifactId>
             <version>1.2.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>cloudbees-folder</artifactId>
+            <version>5.3</version>
+        </dependency>
+
 
         <!-- Test dependancies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins.plugins.statistics.gatherer</groupId>
     <artifactId>statistics-gatherer</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Statistics Gatherer Plugin</name>
@@ -57,8 +57,9 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <powermock.version>1.6.5</powermock.version>
-        <jenkins.version>1.645</jenkins.version>
+        <jenkins.version>2.60.1</jenkins.version>
+        <java.level>8</java.level>
+        <powermock.version>1.7.4</powermock.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -123,13 +124,13 @@
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-war</artifactId>
             <type>war</type>
-            <version>1.650</version>
+            <version>${jenkins.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-test-harness</artifactId>
-            <version>1.644</version>
+            <version>${jenkins-test-harness.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -173,7 +174,6 @@
                 <!-- version specified in grandparent pom -->
                 <extensions>true</extensions>
                 <configuration>
-                    <showDeprecation>true</showDeprecation>
                     <disabledTestInjection>true</disabledTestInjection>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-test-harness</artifactId>
+            <version>1.644</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
@@ -27,6 +27,7 @@ public class StatisticsConfiguration extends GlobalConfiguration {
     private String awsAccessKey;
     private String awsSecretKey;
     private String snsTopicArn;
+    private String logbackConfigXmlUrl;
 
     private Boolean queueInfo;
     private Boolean buildInfo;
@@ -35,6 +36,8 @@ public class StatisticsConfiguration extends GlobalConfiguration {
     private Boolean buildStepInfo;
     private Boolean shouldSendApiHttpRequests;
     private Boolean shouldPublishToAwsSnsQueue;
+
+    private Boolean shouldSendToLogback;
 
     public StatisticsConfiguration() {
         load();
@@ -358,5 +361,21 @@ public class StatisticsConfiguration extends GlobalConfiguration {
 
     private boolean validateProtocolUsed(String url) {
         return !(url.startsWith("http://") || url.startsWith("https://"));
+    }
+
+    public Boolean getShouldSendToLogback() {
+        return shouldSendToLogback;
+    }
+
+    public void setShouldSendToLogback(Boolean shouldSendToLogback) {
+        this.shouldSendToLogback = shouldSendToLogback;
+    }
+
+    public String getLogbackConfigXmlUrl() {
+        return logbackConfigXmlUrl;
+    }
+
+    public void setLogbackConfigXmlUrl(String logbackConfigXmlUrl) {
+        this.logbackConfigXmlUrl = logbackConfigXmlUrl;
     }
 }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListener.java
@@ -6,6 +6,7 @@ import hudson.model.BuildListener;
 import hudson.model.BuildStepListener;
 import hudson.tasks.BuildStep;
 import org.jenkins.plugins.statistics.gatherer.model.step.BuildStepStats;
+import org.jenkins.plugins.statistics.gatherer.util.LogbackUtil;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
 import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
 import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
@@ -29,6 +30,7 @@ public class BuildStepStatsListener extends BuildStepListener {
             buildStepStats.setStartTime(new Date(0));
             RestClientUtil.postToService(getRestUrl(), buildStepStats);
             SnsClientUtil.publishToSns(buildStepStats);
+            LogbackUtil.info(buildStepStats);
         }
     }
 
@@ -43,6 +45,7 @@ public class BuildStepStatsListener extends BuildStepListener {
             buildStepStats.setEndTime(new Date(0));
             RestClientUtil.postToService(getRestUrl(), buildStepStats);
             SnsClientUtil.publishToSns(buildStepStats);
+            LogbackUtil.info(buildStepStats);
         }
     }
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/FolderStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/FolderStatsListener.java
@@ -3,117 +3,28 @@ package org.jenkins.plugins.statistics.gatherer.listeners;
 import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import hudson.Extension;
 import hudson.model.Item;
-import hudson.model.User;
-import hudson.model.listeners.ItemListener;
-import jenkins.model.Jenkins;
 import org.jenkins.plugins.statistics.gatherer.model.job.JobStats;
 import org.jenkins.plugins.statistics.gatherer.util.*;
 
-import java.io.IOException;
 import java.util.Date;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 @Extension
-public class FolderStatsListener extends ItemListener {
-    private static final Logger LOGGER = Logger.getLogger(FolderStatsListener.class.getName());
+public class FolderStatsListener extends GenericItemStatsListener<AbstractFolder<?>> {
 
     public FolderStatsListener() {
         //Necessary for jenkins
-    }
-
-    @Override
-    public void onCreated(Item item) {
-        if (PropertyLoader.getProjectInfo() && canHandle(item)) {
-            try {
-                AbstractFolder<?> folder = asFolder(item);
-                JobStats ciJob = addCIJobData(folder);
-                ciJob.setCreatedDate(new Date());
-                ciJob.setStatus(Constants.ACTIVE);
-                setConfig(folder, ciJob);
-                RestClientUtil.postToService(getRestUrl(), ciJob);
-                SnsClientUtil.publishToSns(ciJob);
-                LogbackUtil.info(ciJob);
-            } catch (Exception e) {
-                logException(item, e);
-            }
-        }
-    }
-
-    private AbstractFolder<?> asFolder(Item item) {
-        if(canHandle(item)) {
-            return (AbstractFolder<?>) item;
-        } else {
-            throw new IllegalArgumentException("Discarding item " + item.getDisplayName() + "/" + item.getClass() + " because it is not an AbstractFolder");
-        }
-    }
-
-    private boolean canHandle(Item item) {
-        return item instanceof AbstractFolder<?>;
-    }
-
-    private void logException(Item item, Exception e) {
-        LOGGER.log(Level.WARNING, "Failed to call API " + getRestUrl() +
-                " for job " + item.getDisplayName(), e);
-    }
-
-    /**
-     * Construct REST API url for project resource.
-     *
-     * @return
-     */
-    private String getRestUrl() {
-        return PropertyLoader.getProjectEndPoint();
-    }
-
-    /**
-     * Construct CIJob model and populate common data in helper method.
-     *
-     * @param project
-     * @return
-     */
-    private JobStats addCIJobData(AbstractFolder<?> project) {
-        JobStats ciJob = new JobStats();
-        ciJob.setJobType(JobStats.JobType.FOLDER);
-        ciJob.setCiUrl(Jenkins.getInstance().getRootUrl());
-        ciJob.setName(project.getName());
-        ciJob.setJobUrl(project.getUrl());
-        String userName = Jenkins.getAuthentication().getName();
-        User user = Jenkins.getInstance().getUser(userName);
-        if(user != null) {
-            ciJob.setUserId(user.getId());
-            ciJob.setUserName(user.getFullName());
-        }
-
-        return ciJob;
-    }
-
-    /**
-     * Get job configuration as a string and store it in DB.
-     *
-     * @param project
-     * @param ciJob
-     */
-    private void setConfig(AbstractFolder<?> project, JobStats ciJob) {
-        try {
-            ciJob.setConfigFile(project.getConfigFile().asString());
-        } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Failed to get config.xml file " +
-                    " for " + project.getDisplayName(), e);
-        }
+        super(JobStats.JobType.FOLDER);
     }
 
     @Override
     public void onUpdated(Item item) {
         if (PropertyLoader.getProjectInfo() && canHandle(item)) {
-            AbstractFolder<?> project = asFolder(item);
+            AbstractFolder<?> project = castItem(item);
             try {
                 JobStats ciJob = addCIJobData(project);
                 ciJob.setUpdatedDate(new Date());
                 setConfig(project, ciJob);
-                RestClientUtil.postToService(getRestUrl(), ciJob);
-                SnsClientUtil.publishToSns(ciJob);
-                LogbackUtil.info(ciJob);
+                publishEvent(ciJob);
             } catch (Exception e) {
                 logException(item, e);
             }
@@ -121,19 +32,7 @@ public class FolderStatsListener extends ItemListener {
     }
 
     @Override
-    public void onDeleted(Item item) {
-        if (PropertyLoader.getProjectInfo() && canHandle(item)) {
-            AbstractFolder<?> project = asFolder(item);
-            try {
-                JobStats ciJob = addCIJobData(project);
-                ciJob.setUpdatedDate(new Date());
-                ciJob.setStatus(Constants.DELETED);
-                RestClientUtil.postToService(getRestUrl(), ciJob);
-                SnsClientUtil.publishToSns(ciJob);
-                LogbackUtil.info(ciJob);
-            } catch (Exception e) {
-                logException(item, e);
-            }
-        }
+    protected boolean canHandle(Item item) {
+        return item instanceof AbstractFolder<?>;
     }
 }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/GenericItemStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/GenericItemStatsListener.java
@@ -1,0 +1,123 @@
+package org.jenkins.plugins.statistics.gatherer.listeners;
+
+import hudson.model.AbstractItem;
+import hudson.model.AbstractProject;
+import hudson.model.Item;
+import hudson.model.User;
+import hudson.model.listeners.ItemListener;
+import jenkins.model.Jenkins;
+import org.jenkins.plugins.statistics.gatherer.model.job.JobStats;
+import org.jenkins.plugins.statistics.gatherer.util.*;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public abstract class GenericItemStatsListener<T extends AbstractItem> extends ItemListener {
+    protected final Logger LOGGER = Logger.getLogger(this.getClass().getName());
+    protected final JobStats.JobType type;
+
+    protected GenericItemStatsListener(JobStats.JobType type) {
+        this.type = type;
+    }
+
+    protected abstract boolean canHandle(Item item);
+
+    protected void logException(Item item, Exception e) {
+        LOGGER.log(Level.WARNING, "Failed to call API " + getRestUrl() +
+                " for job " + item.getDisplayName(), e);
+    }
+
+    /**
+     * Construct REST API url for project resource.
+     *
+     * @return
+     */
+    protected String getRestUrl() {
+        return PropertyLoader.getProjectEndPoint();
+    }
+
+    protected T castItem(Item item) {
+        if (canHandle(item)) {
+            return (T) item;
+        } else {
+            throw new IllegalArgumentException("Discarding item " + item.getDisplayName() + "/" + item.getClass()
+                    + " because it is not of the expected type");
+        }
+    }
+
+    @Override
+    public void onCreated(Item item) {
+        if (PropertyLoader.getProjectInfo() && canHandle(item)) {
+            try {
+                T typedItem = castItem(item);
+                JobStats ciJob = addCIJobData(typedItem);
+                ciJob.setCreatedDate(new Date());
+                ciJob.setStatus(Constants.ACTIVE);
+                setConfig(typedItem, ciJob);
+                publishEvent(ciJob);
+            } catch (Exception e) {
+                logException(item, e);
+            }
+        }
+    }
+
+    @Override
+    public void onDeleted(Item item) {
+        if (PropertyLoader.getProjectInfo() && canHandle(item)) {
+            T project = castItem(item);
+            try {
+                JobStats ciJob = addCIJobData(project);
+                ciJob.setUpdatedDate(new Date());
+                ciJob.setStatus(Constants.DELETED);
+                publishEvent(ciJob);
+            } catch (Exception e) {
+                logException(item, e);
+            }
+        }
+    }
+
+    /**
+     * Get job configuration as a string and store it in DB.
+     *
+     * @param item
+     * @param ciJob
+     */
+    protected void setConfig(T item, JobStats ciJob) {
+        try {
+            ciJob.setConfigFile(item.getConfigFile().asString());
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to get config.xml file " +
+                    " for " + item.getDisplayName(), e);
+        }
+    }
+
+    /**
+     * Construct CIJob model and populate common data in helper method.
+     *
+     * @param item
+     * @return
+     */
+    protected JobStats addCIJobData(T item) {
+        JobStats ciJob = new JobStats();
+        ciJob.setJobType(type);
+        ciJob.setCiUrl(Jenkins.getInstance().getRootUrl());
+        ciJob.setName(item.getName());
+        ciJob.setJobUrl(item.getUrl());
+        String userName = Jenkins.getAuthentication().getName();
+        User user = Jenkins.getInstance().getUser(userName);
+        if (user != null) {
+            ciJob.setUserId(user.getId());
+            ciJob.setUserName(user.getFullName());
+        }
+
+        return ciJob;
+    }
+
+    protected void publishEvent(Object event) {
+        RestClientUtil.postToService(getRestUrl(), event);
+        SnsClientUtil.publishToSns(event);
+        LogbackUtil.info(event);
+    }
+}

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
@@ -7,10 +7,7 @@ import hudson.model.User;
 import hudson.model.listeners.ItemListener;
 import jenkins.model.Jenkins;
 import org.jenkins.plugins.statistics.gatherer.model.job.JobStats;
-import org.jenkins.plugins.statistics.gatherer.util.Constants;
-import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
-import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
-import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
+import org.jenkins.plugins.statistics.gatherer.util.*;
 
 import java.io.IOException;
 import java.util.Date;
@@ -42,6 +39,7 @@ public class ItemStatsListener extends ItemListener {
                 setConfig(project, ciJob);
                 RestClientUtil.postToService(getRestUrl(), ciJob);
                 SnsClientUtil.publishToSns(ciJob);
+                LogbackUtil.info(ciJob);
             } catch (Exception e) {
                 logException(item, e);
             }
@@ -110,6 +108,7 @@ public class ItemStatsListener extends ItemListener {
                 setConfig(project, ciJob);
                 RestClientUtil.postToService(getRestUrl(), ciJob);
                 SnsClientUtil.publishToSns(ciJob);
+                LogbackUtil.info(ciJob);
             } catch (Exception e) {
                 logException(item, e);
             }
@@ -129,6 +128,7 @@ public class ItemStatsListener extends ItemListener {
                 ciJob.setStatus(Constants.DELETED);
                 RestClientUtil.postToService(getRestUrl(), ciJob);
                 SnsClientUtil.publishToSns(ciJob);
+                LogbackUtil.info(ciJob);
             } catch (Exception e) {
                 logException(item, e);
             }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
@@ -3,121 +3,32 @@ package org.jenkins.plugins.statistics.gatherer.listeners;
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.Item;
-import hudson.model.User;
-import hudson.model.listeners.ItemListener;
-import jenkins.model.Jenkins;
 import org.jenkins.plugins.statistics.gatherer.model.job.JobStats;
 import org.jenkins.plugins.statistics.gatherer.util.*;
 
-import java.io.IOException;
 import java.util.Date;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Created by hthakkallapally on 3/12/2015.
  */
 @Extension
-public class ItemStatsListener extends ItemListener {
-    private static final Logger LOGGER = Logger.getLogger(ItemStatsListener.class.getName());
+public class ItemStatsListener extends GenericItemStatsListener<AbstractProject<?,?>> {
 
     public ItemStatsListener() {
         //Necessary for jenkins
-    }
-
-    @Override
-    public void onCreated(Item item) {
-        if (PropertyLoader.getProjectInfo() && canHandle(item)) {
-            try {
-                AbstractProject<?, ?> project = asProject(item);
-                JobStats ciJob = addCIJobData(project);
-                ciJob.setCreatedDate(new Date());
-                ciJob.setStatus(Constants.ACTIVE);
-                setConfig(project, ciJob);
-                RestClientUtil.postToService(getRestUrl(), ciJob);
-                SnsClientUtil.publishToSns(ciJob);
-                LogbackUtil.info(ciJob);
-            } catch (Exception e) {
-                logException(item, e);
-            }
-        }
-    }
-
-    private AbstractProject<?, ?> asProject(Item item) {
-        if(canHandle(item)) {
-            return (AbstractProject<?, ?>) item;
-        } else {
-            throw new IllegalArgumentException("Discarding item " + item.getDisplayName() + "/" + item.getClass() + " because it is not an AbstractProject");
-        }
-    }
-
-    private boolean canHandle(Item item) {
-        return item instanceof AbstractProject<?, ?>;
-    }
-
-    private void logException(Item item, Exception e) {
-        LOGGER.log(Level.WARNING, "Failed to call API " + getRestUrl() +
-                " for job " + item.getDisplayName(), e);
-    }
-
-    /**
-     * Construct REST API url for project resource.
-     *
-     * @return
-     */
-    private String getRestUrl() {
-        return PropertyLoader.getProjectEndPoint();
-    }
-
-    /**
-     * Construct CIJob model and populate common data in helper method.
-     *
-     * @param project
-     * @return
-     */
-    private JobStats addCIJobData(AbstractProject<?, ?> project) {
-        JobStats ciJob = new JobStats();
-        ciJob.setJobType(JobStats.JobType.PROJECT);
-        ciJob.setCiUrl(Jenkins.getInstance().getRootUrl());
-        ciJob.setName(project.getName());
-        ciJob.setJobUrl(project.getUrl());
-        String userName = Jenkins.getAuthentication().getName();
-        User user = Jenkins.getInstance().getUser(userName);
-        if(user != null) {
-            ciJob.setUserId(user.getId());
-            ciJob.setUserName(user.getFullName());
-        }
-
-        return ciJob;
-    }
-
-    /**
-     * Get job configuration as a string and store it in DB.
-     *
-     * @param project
-     * @param ciJob
-     */
-    private void setConfig(AbstractProject<?, ?> project, JobStats ciJob) {
-        try {
-            ciJob.setConfigFile(project.getConfigFile().asString());
-        } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Failed to get config.xml file " +
-                    " for " + project.getDisplayName(), e);
-        }
+        super(JobStats.JobType.PROJECT);
     }
 
     @Override
     public void onUpdated(Item item) {
         if (PropertyLoader.getProjectInfo() && canHandle(item)) {
-            AbstractProject<?, ?> project = asProject(item);
+            AbstractProject<?,?> project = castItem(item);
             try {
                 JobStats ciJob = addCIJobData(project);
                 ciJob.setUpdatedDate(new Date());
                 ciJob.setStatus(project.isDisabled() ? Constants.DISABLED : Constants.ACTIVE);
                 setConfig(project, ciJob);
-                RestClientUtil.postToService(getRestUrl(), ciJob);
-                SnsClientUtil.publishToSns(ciJob);
-                LogbackUtil.info(ciJob);
+                publishEvent(ciJob);
             } catch (Exception e) {
                 logException(item, e);
             }
@@ -125,19 +36,7 @@ public class ItemStatsListener extends ItemListener {
     }
 
     @Override
-    public void onDeleted(Item item) {
-        if (PropertyLoader.getProjectInfo() && canHandle(item)) {
-            AbstractProject<?, ?> project = asProject(item);
-            try {
-                JobStats ciJob = addCIJobData(project);
-                ciJob.setUpdatedDate(new Date());
-                ciJob.setStatus(Constants.DELETED);
-                RestClientUtil.postToService(getRestUrl(), ciJob);
-                SnsClientUtil.publishToSns(ciJob);
-                LogbackUtil.info(ciJob);
-            } catch (Exception e) {
-                logException(item, e);
-            }
-        }
+    protected boolean canHandle(Item item) {
+        return item instanceof AbstractProject<?, ?>;
     }
 }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
@@ -27,12 +27,9 @@ public class ItemStatsListener extends ItemListener {
 
     @Override
     public void onCreated(Item item) {
-        if (PropertyLoader.getProjectInfo()) {
+        if (PropertyLoader.getProjectInfo() && canHandle(item)) {
             try {
-                if (item == null) {
-                    return;
-                }
-                AbstractProject<?, ?> project = (AbstractProject<?, ?>) item;
+                AbstractProject<?, ?> project = asProject(item);
                 JobStats ciJob = addCIJobData(project);
                 ciJob.setCreatedDate(new Date());
                 ciJob.setStatus(Constants.ACTIVE);
@@ -44,6 +41,18 @@ public class ItemStatsListener extends ItemListener {
                 logException(item, e);
             }
         }
+    }
+
+    private AbstractProject<?, ?> asProject(Item item) {
+        if(canHandle(item)) {
+            return (AbstractProject<?, ?>) item;
+        } else {
+            throw new IllegalArgumentException("Discarding item " + item.getDisplayName() + "/" + item.getClass() + " because it is not an AbstractProject");
+        }
+    }
+
+    private boolean canHandle(Item item) {
+        return item instanceof AbstractProject<?, ?>;
     }
 
     private void logException(Item item, Exception e) {
@@ -96,12 +105,9 @@ public class ItemStatsListener extends ItemListener {
 
     @Override
     public void onUpdated(Item item) {
-        if (PropertyLoader.getProjectInfo()) {
-            AbstractProject<?, ?> project = (AbstractProject<?, ?>) item;
+        if (PropertyLoader.getProjectInfo() && canHandle(item)) {
+            AbstractProject<?, ?> project = asProject(item);
             try {
-                if (item == null) {
-                    return;
-                }
                 JobStats ciJob = addCIJobData(project);
                 ciJob.setUpdatedDate(new Date());
                 ciJob.setStatus(project.isDisabled() ? Constants.DISABLED : Constants.ACTIVE);
@@ -117,12 +123,9 @@ public class ItemStatsListener extends ItemListener {
 
     @Override
     public void onDeleted(Item item) {
-        if (PropertyLoader.getProjectInfo()) {
-            AbstractProject<?, ?> project = (AbstractProject<?, ?>) item;
+        if (PropertyLoader.getProjectInfo() && canHandle(item)) {
+            AbstractProject<?, ?> project = asProject(item);
             try {
-                if (item == null) {
-                    return;
-                }
                 JobStats ciJob = addCIJobData(project);
                 ciJob.setUpdatedDate(new Date());
                 ciJob.setStatus(Constants.DELETED);

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/QueueStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/QueueStatsListener.java
@@ -41,6 +41,7 @@ public class QueueStatsListener extends QueueListener {
                     addEntryQueueCause("waiting", waitingItem, queue);
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
+                LogbackUtil.info(queue);
             } catch (Exception e) {
                 logExceptionWaiting(waitingItem, e);
             }
@@ -73,6 +74,7 @@ public class QueueStatsListener extends QueueListener {
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
                 SnsClientUtil.publishToSns(queue);
+                LogbackUtil.info(queue);
             } catch (Exception e) {
                 logExceptionWaiting(waitingItem, e);
             }
@@ -127,6 +129,7 @@ public class QueueStatsListener extends QueueListener {
 
                 RestClientUtil.postToService(getRestUrl(), queue);
                 SnsClientUtil.publishToSns(queue);
+                LogbackUtil.info(queue);
             } catch (Exception e) {
                 logExceptionBlocked(blockedItem, e);
             }
@@ -143,6 +146,7 @@ public class QueueStatsListener extends QueueListener {
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
                 SnsClientUtil.publishToSns(queue);
+                LogbackUtil.info(queue);
             } catch (Exception e) {
                 logExceptionLeave(buildableItem, e);
             }
@@ -159,6 +163,7 @@ public class QueueStatsListener extends QueueListener {
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
                 SnsClientUtil.publishToSns(queue);
+                LogbackUtil.info(queue);
             } catch (Exception e) {
                 logExceptionLeave(buildableItem, e);
             }
@@ -215,6 +220,7 @@ public class QueueStatsListener extends QueueListener {
                 queue.setContextId(leftItem.outcome.hashCode());
                 RestClientUtil.postToService(getRestUrl(), queue);
                 SnsClientUtil.publishToSns(queue);
+                LogbackUtil.info(queue);
             } catch (Exception e) {
                 logExceptionLeft(leftItem, e);
             }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
@@ -65,6 +65,7 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
                 addSlaveInfo(run, build, listener);
                 RestClientUtil.postToService(getRestUrl(), build);
                 SnsClientUtil.publishToSns(build);
+                LogbackUtil.info(build);
                 LOGGER.log(Level.INFO, "Started build and its status is : " + buildResult +
                         " and start time is : " + run.getTimestamp().getTime());
             } catch (Exception e) {
@@ -226,6 +227,7 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
                 addBuildFailureCauses(build);
                 RestClientUtil.postToService(getRestUrl(), build);
                 SnsClientUtil.publishToSns(build);
+                LogbackUtil.info(build);
                 LOGGER.log(Level.INFO, run.getParent().getName() + " build is completed " +
                         "its status is : " + buildResult +
                         " at time : " + new Date());
@@ -272,6 +274,7 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
             scmCheckoutInfo.setEndTime(new Date(0));
             RestClientUtil.postToService(getScmCheckoutUrl(), scmCheckoutInfo);
             SnsClientUtil.publishToSns(scmCheckoutInfo);
+            LogbackUtil.info(scmCheckoutInfo);
         }
         return super.setUpEnvironment(build, launcher, listener);
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
@@ -222,6 +222,7 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
                 build.setBuildUrl(run.getUrl());
                 build.setDuration(run.getDuration());
                 build.setEndTime(Calendar.getInstance().getTime());
+                addSCMInfo(run, SoutTaskListener.INSTANCE, build);
                 addBuildFailureCauses(build);
                 RestClientUtil.postToService(getRestUrl(), build);
                 SnsClientUtil.publishToSns(build);

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListener.java
@@ -9,6 +9,7 @@ import hudson.model.listeners.SCMListener;
 import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
 import org.jenkins.plugins.statistics.gatherer.model.scm.ScmCheckoutInfo;
+import org.jenkins.plugins.statistics.gatherer.util.LogbackUtil;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
 import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
 import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
@@ -35,6 +36,7 @@ public class ScmStatsListener extends SCMListener{
             scmCheckoutInfo.setEndTime(Calendar.getInstance().getTime());
             RestClientUtil.postToService(getUrl(), scmCheckoutInfo);
             SnsClientUtil.publishToSns(scmCheckoutInfo);
+            LogbackUtil.info(scmCheckoutInfo);
         }
     }
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/SoutTaskListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/SoutTaskListener.java
@@ -1,0 +1,49 @@
+package org.jenkins.plugins.statistics.gatherer.listeners;
+
+import hudson.console.ConsoleNote;
+import hudson.model.TaskListener;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
+public class SoutTaskListener implements TaskListener {
+    private static PrintWriter soutWriter = new PrintWriter(System.out);
+
+    public static final SoutTaskListener INSTANCE = new SoutTaskListener();
+
+    @Override
+    public PrintStream getLogger() {
+        return System.out;
+    }
+
+    @Override
+    public void annotate(ConsoleNote ann) throws IOException {
+
+    }
+
+    @Override
+    public void hyperlink(String url, String text) throws IOException {
+
+    }
+
+    @Override
+    public PrintWriter error(String msg) {
+        return soutWriter;
+    }
+
+    @Override
+    public PrintWriter error(String format, Object... args) {
+        return soutWriter;
+    }
+
+    @Override
+    public PrintWriter fatalError(String msg) {
+        return soutWriter;
+    }
+
+    @Override
+    public PrintWriter fatalError(String format, Object... args) {
+        return soutWriter;
+    }
+}

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/model/job/JobStats.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/model/job/JobStats.java
@@ -7,6 +7,10 @@ import java.util.Date;
  */
 public class JobStats {
 
+    public static enum JobType {
+        FOLDER, PROJECT
+    }
+
     private String name;
 
     private Date createdDate;
@@ -25,6 +29,8 @@ public class JobStats {
 
     private String jobUrl;
 
+    private JobType jobType;
+
     public JobStats(String name,
                     Date createdDate,
                     String userId,
@@ -33,7 +39,8 @@ public class JobStats {
                     Date updatedDate,
                     String status,
                     String configFile,
-                    String jobUrl) {
+                    String jobUrl,
+                    JobType jobType) {
         this.name = name;
         this.createdDate = createdDate;
         this.userId = userId;
@@ -43,6 +50,7 @@ public class JobStats {
         this.status = status;
         this.configFile = configFile;
         this.jobUrl = jobUrl;
+        this.jobType = jobType;
     }
 
     public JobStats() {
@@ -127,5 +135,13 @@ public class JobStats {
 
     public void setJobUrl(String jobUrl) {
         this.jobUrl = jobUrl;
+    }
+
+    public JobType getJobType() {
+        return jobType;
+    }
+
+    public void setJobType(JobType jobType) {
+        this.jobType = jobType;
     }
 }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/LogbackUtil.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/LogbackUtil.java
@@ -1,0 +1,44 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.util.ContextInitializer;
+import ch.qos.logback.core.joran.spi.JoranException;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class LogbackUtil {
+    private static final String STATISTICS_GATHERER_LOGGER = "statistics-gatherer";
+    private static Logger log;
+
+    private static Logger getLogger(String loggerName) {
+        LoggerContext loggerContext = new LoggerContext();
+        ContextInitializer contextInitializer = new ContextInitializer(loggerContext);
+        try {
+            String configurationUrlString = PropertyLoader.getLogbackConfigXmlUrl();
+            if (configurationUrlString == null) {
+                throw new IllegalStateException("LOGBack XML configuration file not specified");
+            }
+
+            URL configurationUrl = new URL(configurationUrlString);
+            contextInitializer.configureByResource(configurationUrl);
+            return loggerContext.getLogger(loggerName);
+        } catch (JoranException e) {
+            throw new RuntimeException("Unable to configure logger", e);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Unable to find LOGBack XML configuration", e);
+        }
+    }
+
+    public static void info(Object object) {
+        if (PropertyLoader.getShouldSendToLogback()) {
+            if(log == null) {
+                synchronized (LogbackUtil.class) {
+                    log = getLogger(STATISTICS_GATHERER_LOGGER);
+                }
+            }
+            log.info(JSONUtil.convertToJson(object));
+        }
+    }
+}

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
@@ -209,4 +209,21 @@ public class PropertyLoader {
         String shouldPublishToAwsSnsQueueEnv = getEnvironmentProperty("statistics.endpoint.shouldPublishToAwsSnsQueue");
         return "true".equals(shouldPublishToAwsSnsQueueEnv);
     }
+
+    public static boolean getShouldSendToLogback() {
+        Boolean shouldSendToLogback = StatisticsConfiguration.get().getShouldSendToLogback();
+        if (shouldSendToLogback != null) {
+            return shouldSendToLogback;
+        }
+        String shouldSendToLogbackEnv = getEnvironmentProperty("statistics.endpoint.shouldSendToLogback");
+        return "true".equals(shouldSendToLogbackEnv);
+    }
+
+    public static String getLogbackConfigXmlUrl() {
+        String logbackConfigXmlUrlString = StatisticsConfiguration.get().getLogbackConfigXmlUrl();
+        if (logbackConfigXmlUrlString == null) {
+            logbackConfigXmlUrlString = getEnvironmentProperty("statistics.endpoint.logbackConfigXmlUrl");
+        }
+        return logbackConfigXmlUrlString;
+    }
 }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/RestClientUtil.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/RestClientUtil.java
@@ -23,27 +23,31 @@ public class RestClientUtil {
 
     public static void postToService(final String url, Object object) {
         if (PropertyLoader.getShouldSendApiHttpRequests()) {
-            String jsonToPost = JSONUtil.convertToJson(object);
-            Unirest.post(url)
-                    .header(ACCEPT, APPLICATION_JSON)
-                    .header(CONTENT_TYPE, APPLICATION_JSON)
-                    .body(jsonToPost)
-                    .asJsonAsync(new Callback<JsonNode>() {
+            try {
+                String jsonToPost = JSONUtil.convertToJson(object);
+                Unirest.post(url)
+                        .header(ACCEPT, APPLICATION_JSON)
+                        .header(CONTENT_TYPE, APPLICATION_JSON)
+                        .body(jsonToPost)
+                        .asJsonAsync(new Callback<JsonNode>() {
 
-                        public void failed(UnirestException e) {
-                            LOGGER.log(Level.WARNING, "The request for url " + url + " has failed.", e);
-                        }
+                            public void failed(UnirestException e) {
+                                LOGGER.log(Level.WARNING, "The request for url " + url + " has failed.", e);
+                            }
 
-                        public void completed(HttpResponse<JsonNode> response) {
-                            int responseCode = response.getStatus();
-                            LOGGER.log(Level.INFO, "The request for url " + url + " completed with status " + responseCode);
-                        }
+                            public void completed(HttpResponse<JsonNode> response) {
+                                int responseCode = response.getStatus();
+                                LOGGER.log(Level.INFO, "The request for url " + url + " completed with status " + responseCode);
+                            }
 
-                        public void cancelled() {
-                            LOGGER.log(Level.INFO, "The request for url " + url + " has been cancelled");
-                        }
+                            public void cancelled() {
+                                LOGGER.log(Level.INFO, "The request for url " + url + " has been cancelled");
+                            }
 
-                    });
+                        });
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Unable to post event to url {}" + url, e);
+            }
         }
     }
 

--- a/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
+++ b/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
@@ -60,5 +60,13 @@ f.section(title:_("Statistics Gatherer")) {
         f.entry(title:_("Enable HTTP publishing?"), field:"shouldSendApiHttpRequests") {
             f.checkbox(default: instance.shouldSendApiHttpRequests == null ? true : instance.shouldSendApiHttpRequests.equals(true));
         }
+
+        f.entry(title:_("Enable publish of events to LOGBack"), field:"shouldSendToLogback") {
+            f.checkbox(default: false)
+        }
+
+        f.entry(title:_("LOGBack XML configuration URL"), field:"logbackConfigXmlUrl") {
+            f.textbox()
+        }
     }
 }

--- a/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/help-logbackConfigXmlUrl.html
+++ b/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/help-logbackConfigXmlUrl.html
@@ -1,0 +1,3 @@
+<div>
+    URL of the <a href="https://logback.qos.ch/manual/configuration.html" target="_blank">LOGBack XML</a> configuration file<br/>
+</div>

--- a/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/help-shouldSendToLogback.html
+++ b/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/help-shouldSendToLogback.html
@@ -1,0 +1,3 @@
+<div>
+    Allow to push events to a <a href="https://logback.qos.ch/manual/appenders.html"  target="_blank">LOGBack Appender</a><br/>
+</div>

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListenerTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListenerTest.java
@@ -4,6 +4,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.tasks.BuildStep;
 import org.jenkins.plugins.statistics.gatherer.model.step.BuildStepStats;
+import org.jenkins.plugins.statistics.gatherer.util.LogbackUtil;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
 import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
 import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
@@ -27,7 +28,7 @@ import static org.mockito.Matchers.anyString;
  */
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({PropertyLoader.class, RestClientUtil.class, SnsClientUtil.class})
+@PrepareForTest({PropertyLoader.class, RestClientUtil.class, SnsClientUtil.class, LogbackUtil.class})
 public class BuildStepStatsListenerTest {
 
     private BuildStepStatsListener listener;
@@ -57,7 +58,6 @@ public class BuildStepStatsListenerTest {
         BuildStepStats buildStepStats = buildStepStatsArgumentCaptor.getValue();
         assertEquals("aUrl", buildStepStats.getBuildUrl());
         assertEquals(new Date(0), buildStepStats.getEndTime());
-
     }
 
     @Test

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListenerTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListenerTest.java
@@ -1,0 +1,97 @@
+package org.jenkins.plugins.statistics.gatherer.listeners;
+
+import hudson.model.Build;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.TaskListener;
+import hudson.model.queue.QueueTaskFuture;
+import hudson.tasks.Shell;
+import jenkins.model.Jenkins;
+import org.jenkins.plugins.statistics.gatherer.model.build.BuildStats;
+import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
+import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.ArgumentCaptor;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.isNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import static org.hamcrest.CoreMatchers.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PropertyLoader.class, RestClientUtil.class})
+@PowerMockIgnore({"javax.crypto.*"})
+public class RunStatsListenerTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private RunStatsListener listener;
+    private TaskListener soutListener = new SoutTaskListener();
+
+    @Before
+    public void setup() {
+        listener = new RunStatsListener();
+        mockStatic(PropertyLoader.class);
+        mockStatic(RestClientUtil.class);
+    }
+
+    @Test
+    public void givenRunWithBuildInfoTrue_whenStarted_thenPostTwice() throws Exception {
+        when(PropertyLoader.getBuildInfo()).thenReturn(true);
+
+        Build<?, ?> build = triggerNewBuild().get();
+
+        verifyStatic(times(2));
+        ArgumentCaptor<BuildStats> captor =
+                ArgumentCaptor.forClass(BuildStats.class);
+        RestClientUtil.postToService(anyString(), captor.capture());
+        BuildStats buildStats = captor.getAllValues().get(0);
+
+        assertThat(buildStats.getResult(), is(equalTo("INPROGRESS")));
+        assertBuildInfoEqualsTo(buildStats, build);
+    }
+
+    @Test
+    public void givenRunWithBuildInfoTrue_whenCompleted_thenPost() throws Exception {
+        when(PropertyLoader.getBuildInfo()).thenReturn(true);
+
+        Build<?, ?> build = triggerNewBuild().get();
+
+        verifyStatic(times(2));
+        ArgumentCaptor<BuildStats> captor =
+                ArgumentCaptor.forClass(BuildStats.class);
+        RestClientUtil.postToService(anyString(), captor.capture());
+        BuildStats buildStats = captor.getAllValues().get(1);
+
+        assertThat(buildStats.getResult(), is(equalTo("SUCCESS")));
+        assertBuildInfoEqualsTo(buildStats, build);
+    }
+
+    private void assertBuildInfoEqualsTo(BuildStats buildStats, Build<?, ?> build) {
+        assertThat(buildStats.getBuildUrl(), is(build.getUrl()));
+        assertThat(buildStats.getStartTime(), is(notNullValue()));
+        assertThat(buildStats.getBuildCause(), is(notNullValue()));
+        assertThat(buildStats.getFullJobName(), is(build.getParent().getFullName()));
+        assertThat(buildStats.getJobName(), is(build.getParent().getName()));
+        assertThat(buildStats.getNumber(), is(build.getNumber()));
+    }
+
+    private QueueTaskFuture<FreeStyleBuild> triggerNewBuild() throws IOException {
+        FreeStyleProject project = j.createFreeStyleProject();
+        project.getBuildersList().add(new Shell("echo hello"));
+        return project.scheduleBuild2(0);
+    }
+}

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/model/job/JobStatsTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/model/job/JobStatsTest.java
@@ -37,7 +37,8 @@ public class JobStatsTest {
                 UPDATED_DATE,
                 STATUS,
                 CONFIG_FILE,
-                JOB_URL);
+                JOB_URL,
+                JobStats.JobType.PROJECT);
     }
 
     @Test


### PR DESCRIPTION
Add an optional dependency to the forthcoming plugin that includes
    the LOGBack appender to push events to the NATS pub/sub broker.