### PR TITLE
Add missing test scope to Mockito

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.10.19</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>


### PR DESCRIPTION
Mockito is used only during the unit and integration
test phases and should be then excluded from the plugin's
packaging.

Change-Id: Ia92945db4824a8f8f3b98496b019508da03f431c