### PR TITLE
Allow to send events to NATS topic through LOGBack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.7.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>logback-nats-appender</artifactId>
+            <version>0.2.2</version>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Test dependancies -->
         <dependency>

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
@@ -27,6 +27,7 @@ public class StatisticsConfiguration extends GlobalConfiguration {
     private String awsAccessKey;
     private String awsSecretKey;
     private String snsTopicArn;
+    private String logbackConfigXmlUrl;
 
     private Boolean queueInfo;
     private Boolean buildInfo;
@@ -35,6 +36,8 @@ public class StatisticsConfiguration extends GlobalConfiguration {
     private Boolean buildStepInfo;
     private Boolean shouldSendApiHttpRequests;
     private Boolean shouldPublishToAwsSnsQueue;
+
+    private Boolean shouldSendToLogback;
 
     public StatisticsConfiguration() {
         load();
@@ -358,5 +361,21 @@ public class StatisticsConfiguration extends GlobalConfiguration {
 
     private boolean validateProtocolUsed(String url) {
         return !(url.startsWith("http://") || url.startsWith("https://"));
+    }
+
+    public Boolean getShouldSendToLogback() {
+        return shouldSendToLogback;
+    }
+
+    public void setShouldSendToLogback(Boolean shouldSendToLogback) {
+        this.shouldSendToLogback = shouldSendToLogback;
+    }
+
+    public String getLogbackConfigXmlUrl() {
+        return logbackConfigXmlUrl;
+    }
+
+    public void setLogbackConfigXmlUrl(String logbackConfigXmlUrl) {
+        this.logbackConfigXmlUrl = logbackConfigXmlUrl;
     }
 }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListener.java
@@ -6,6 +6,7 @@ import hudson.model.BuildListener;
 import hudson.model.BuildStepListener;
 import hudson.tasks.BuildStep;
 import org.jenkins.plugins.statistics.gatherer.model.step.BuildStepStats;
+import org.jenkins.plugins.statistics.gatherer.util.LogbackUtil;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
 import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
 import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
@@ -29,6 +30,7 @@ public class BuildStepStatsListener extends BuildStepListener {
             buildStepStats.setStartTime(new Date(0));
             RestClientUtil.postToService(getRestUrl(), buildStepStats);
             SnsClientUtil.publishToSns(buildStepStats);
+            LogbackUtil.info(buildStepStats);
         }
     }
 
@@ -43,6 +45,7 @@ public class BuildStepStatsListener extends BuildStepListener {
             buildStepStats.setEndTime(new Date(0));
             RestClientUtil.postToService(getRestUrl(), buildStepStats);
             SnsClientUtil.publishToSns(buildStepStats);
+            LogbackUtil.info(buildStepStats);
         }
     }
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
@@ -7,10 +7,7 @@ import hudson.model.User;
 import hudson.model.listeners.ItemListener;
 import jenkins.model.Jenkins;
 import org.jenkins.plugins.statistics.gatherer.model.job.JobStats;
-import org.jenkins.plugins.statistics.gatherer.util.Constants;
-import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
-import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
-import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
+import org.jenkins.plugins.statistics.gatherer.util.*;
 
 import java.io.IOException;
 import java.util.Date;
@@ -39,6 +36,7 @@ public class ItemStatsListener extends ItemListener {
                 setConfig(project, ciJob);
                 RestClientUtil.postToService(getRestUrl(), ciJob);
                 SnsClientUtil.publishToSns(ciJob);
+                LogbackUtil.info(ciJob);
             } catch (Exception e) {
                 logException(item, e);
             }
@@ -84,8 +82,10 @@ public class ItemStatsListener extends ItemListener {
         ciJob.setJobUrl(project.getUrl());
         String userName = Jenkins.getAuthentication().getName();
         User user = Jenkins.getInstance().getUser(userName);
-        ciJob.setUserId(user.getId());
-        ciJob.setUserName(user.getFullName());
+        if(user != null) {
+            ciJob.setUserId(user.getId());
+            ciJob.setUserName(user.getFullName());
+        }
 
         return ciJob;
     }
@@ -116,6 +116,7 @@ public class ItemStatsListener extends ItemListener {
                 setConfig(project, ciJob);
                 RestClientUtil.postToService(getRestUrl(), ciJob);
                 SnsClientUtil.publishToSns(ciJob);
+                LogbackUtil.info(ciJob);
             } catch (Exception e) {
                 logException(item, e);
             }
@@ -132,6 +133,7 @@ public class ItemStatsListener extends ItemListener {
                 ciJob.setStatus(Constants.DELETED);
                 RestClientUtil.postToService(getRestUrl(), ciJob);
                 SnsClientUtil.publishToSns(ciJob);
+                LogbackUtil.info(ciJob);
             } catch (Exception e) {
                 logException(item, e);
             }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/QueueStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/QueueStatsListener.java
@@ -41,6 +41,7 @@ public class QueueStatsListener extends QueueListener {
                     addEntryQueueCause("waiting", waitingItem, queue);
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
+                LogbackUtil.info(queue);
             } catch (Exception e) {
                 logExceptionWaiting(waitingItem, e);
             }
@@ -73,6 +74,7 @@ public class QueueStatsListener extends QueueListener {
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
                 SnsClientUtil.publishToSns(queue);
+                LogbackUtil.info(queue);
             } catch (Exception e) {
                 logExceptionWaiting(waitingItem, e);
             }
@@ -127,6 +129,7 @@ public class QueueStatsListener extends QueueListener {
 
                 RestClientUtil.postToService(getRestUrl(), queue);
                 SnsClientUtil.publishToSns(queue);
+                LogbackUtil.info(queue);
             } catch (Exception e) {
                 logExceptionBlocked(blockedItem, e);
             }
@@ -143,6 +146,7 @@ public class QueueStatsListener extends QueueListener {
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
                 SnsClientUtil.publishToSns(queue);
+                LogbackUtil.info(queue);
             } catch (Exception e) {
                 logExceptionLeave(buildableItem, e);
             }
@@ -159,6 +163,7 @@ public class QueueStatsListener extends QueueListener {
                 }
                 RestClientUtil.postToService(getRestUrl(), queue);
                 SnsClientUtil.publishToSns(queue);
+                LogbackUtil.info(queue);
             } catch (Exception e) {
                 logExceptionLeave(buildableItem, e);
             }
@@ -215,6 +220,7 @@ public class QueueStatsListener extends QueueListener {
                 queue.setContextId(leftItem.outcome.hashCode());
                 RestClientUtil.postToService(getRestUrl(), queue);
                 SnsClientUtil.publishToSns(queue);
+                LogbackUtil.info(queue);
             } catch (Exception e) {
                 logExceptionLeft(leftItem, e);
             }

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
@@ -65,6 +65,7 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
                 addSlaveInfo(run, build, listener);
                 RestClientUtil.postToService(getRestUrl(), build);
                 SnsClientUtil.publishToSns(build);
+                LogbackUtil.info(build);
                 LOGGER.log(Level.INFO, "Started build and its status is : " + buildResult +
                         " and start time is : " + run.getTimestamp().getTime());
             } catch (Exception e) {
@@ -226,6 +227,7 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
                 addBuildFailureCauses(build);
                 RestClientUtil.postToService(getRestUrl(), build);
                 SnsClientUtil.publishToSns(build);
+                LogbackUtil.info(build);
                 LOGGER.log(Level.INFO, run.getParent().getName() + " build is completed " +
                         "its status is : " + buildResult +
                         " at time : " + new Date());
@@ -272,6 +274,7 @@ public class RunStatsListener extends RunListener<Run<?, ?>> {
             scmCheckoutInfo.setEndTime(new Date(0));
             RestClientUtil.postToService(getScmCheckoutUrl(), scmCheckoutInfo);
             SnsClientUtil.publishToSns(scmCheckoutInfo);
+            LogbackUtil.info(scmCheckoutInfo);
         }
         return super.setUpEnvironment(build, launcher, listener);
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListener.java
@@ -9,6 +9,7 @@ import hudson.model.listeners.SCMListener;
 import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
 import org.jenkins.plugins.statistics.gatherer.model.scm.ScmCheckoutInfo;
+import org.jenkins.plugins.statistics.gatherer.util.LogbackUtil;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
 import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
 import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
@@ -35,6 +36,7 @@ public class ScmStatsListener extends SCMListener{
             scmCheckoutInfo.setEndTime(Calendar.getInstance().getTime());
             RestClientUtil.postToService(getUrl(), scmCheckoutInfo);
             SnsClientUtil.publishToSns(scmCheckoutInfo);
+            LogbackUtil.info(scmCheckoutInfo);
         }
     }
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/LogbackUtil.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/LogbackUtil.java
@@ -1,0 +1,44 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.util.ContextInitializer;
+import ch.qos.logback.core.joran.spi.JoranException;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class LogbackUtil {
+    private static final String STATISTICS_GATHERER_LOGGER = "statistics-gatherer";
+    private static Logger logger;
+
+    private static Logger getLogger(String loggerName) {
+        LoggerContext loggerContext = new LoggerContext();
+        ContextInitializer contextInitializer = new ContextInitializer(loggerContext);
+        try {
+            String configurationUrlString = PropertyLoader.getLogbackConfigXmlUrl();
+            if (configurationUrlString == null) {
+                throw new IllegalStateException("LOGBack XML configuration file not specified");
+            }
+
+            URL configurationUrl = new URL(configurationUrlString);
+            contextInitializer.configureByResource(configurationUrl);
+            return loggerContext.getLogger(loggerName);
+        } catch (JoranException e) {
+            throw new RuntimeException("Unable to configure logger", e);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Unable to find LOGBack XML configuration", e);
+        }
+    }
+
+    public static void info(Object object) {
+        if (PropertyLoader.getShouldSendToLogback()) {
+            if(logger == null) {
+                synchronized (LogbackUtil.class) {
+                    logger = getLogger(STATISTICS_GATHERER_LOGGER);
+                }
+            }
+            logger.info(JSONUtil.convertToJson(object));
+        }
+    }
+}

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
@@ -1,5 +1,6 @@
 package org.jenkins.plugins.statistics.gatherer.util;
 
+import com.google.common.base.Strings;
 import hudson.EnvVars;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.NodeProperty;
@@ -54,16 +55,29 @@ public class PropertyLoader {
         for (EnvironmentVariablesNodeProperty environmentVariablesNodeProperty : properties) {
             environmentVariables.putAll(environmentVariablesNodeProperty.getEnvVars());
         }
-        final String value = environmentVariables.get(key);
-        if (value == null || value.isEmpty()) {
-            return getResourceBundleProperty(key);
+        String value = environmentVariables.get(key);
+        if (!Strings.isNullOrEmpty(value)) {
+            return value;
         }
-        return value;
+        value = environmentVariables.get(key.toLowerCase());
+        if (!Strings.isNullOrEmpty(value)) {
+            return value;
+        }
+
+        value = getResourceBundleProperty(key);
+        if (!Strings.isNullOrEmpty(value)) {
+            return value;
+        }
+        return getResourceBundleProperty(key.toLowerCase());
     }
 
     public static String getEnvironmentProperty(
             final String key) {
         return getInstance().getProperty(key);
+    }
+
+    public static boolean isTrue(String value) {
+        return value != null ? value.toLowerCase().equals("true") : false;
     }
 
     public static String getQueueEndPoint() {
@@ -153,7 +167,7 @@ public class PropertyLoader {
             return queueInfo;
         }
         String queueInfoEnv = getEnvironmentProperty("statistics.endpoint.queueInfo");
-        return "true".equals(queueInfoEnv);
+        return isTrue(queueInfoEnv);
     }
 
     public static Boolean getBuildInfo() {
@@ -161,8 +175,7 @@ public class PropertyLoader {
         if (buildInfo != null) {
             return buildInfo;
         }
-        String buildInfoEnv = getEnvironmentProperty("statistics.endpoint.buildInfo");
-        return "true".equals(buildInfoEnv);
+        return isTrue(getEnvironmentProperty("statistics.endpoint.buildInfo"));
     }
 
     public static Boolean getProjectInfo() {
@@ -170,8 +183,7 @@ public class PropertyLoader {
         if (projectInfo != null) {
             return projectInfo;
         }
-        String projectInfoEnv = getEnvironmentProperty("statistics.endpoint.projectInfo");
-        return "true".equals(projectInfoEnv);
+        return isTrue(getEnvironmentProperty("statistics.endpoint.projectInfo"));
     }
 
     public static Boolean getBuildStepInfo() {
@@ -179,8 +191,7 @@ public class PropertyLoader {
         if (buildStepInfo != null) {
             return buildStepInfo;
         }
-        String buildStepInfoEnv = getEnvironmentProperty("statistics.endpoint.buildStepInfo");
-        return "true".equals(buildStepInfoEnv);
+        return isTrue(getEnvironmentProperty("statistics.endpoint.buildStepInfo"));
     }
 
     public static Boolean getScmCheckoutInfo() {
@@ -188,8 +199,7 @@ public class PropertyLoader {
         if (scmCheckoutInfo != null) {
             return scmCheckoutInfo;
         }
-        String scmCheckoutInfoEnv = getEnvironmentProperty("statistics.endpoint.scmCheckoutInfo");
-        return "true".equals(scmCheckoutInfoEnv);
+        return isTrue(getEnvironmentProperty("statistics.endpoint.scmCheckoutInfo"));
     }
 
     public static Boolean getShouldSendApiHttpRequests() {
@@ -197,8 +207,7 @@ public class PropertyLoader {
         if (shouldSendApiHttpRequests != null) {
             return shouldSendApiHttpRequests;
         }
-        String shouldSendApiHttpRequestsInfoEnv = getEnvironmentProperty("statistics.endpoint.shouldSendApiHttpRequests");
-        return "true".equals(shouldSendApiHttpRequestsInfoEnv);
+        return isTrue(getEnvironmentProperty("statistics.endpoint.shouldSendApiHttpRequests"));
     }
 
     public static Boolean getShouldPublishToAwsSnsQueue() {
@@ -206,7 +215,22 @@ public class PropertyLoader {
         if (shouldPublishToAwsSnsQueue != null) {
             return shouldPublishToAwsSnsQueue;
         }
-        String shouldPublishToAwsSnsQueueEnv = getEnvironmentProperty("statistics.endpoint.shouldPublishToAwsSnsQueue");
-        return "true".equals(shouldPublishToAwsSnsQueueEnv);
+        return isTrue(getEnvironmentProperty("statistics.endpoint.shouldPublishToAwsSnsQueue"));
+    }
+
+    public static boolean getShouldSendToLogback() {
+        Boolean shouldSendToLogback = StatisticsConfiguration.get().getShouldSendToLogback();
+        if (shouldSendToLogback != null) {
+            return shouldSendToLogback;
+        }
+        return isTrue(getEnvironmentProperty("statistics.endpoint.shouldSendToLogback"));
+    }
+
+    public static String getLogbackConfigXmlUrl() {
+        String logbackConfigXmlUrlString = StatisticsConfiguration.get().getLogbackConfigXmlUrl();
+        if (logbackConfigXmlUrlString == null) {
+            logbackConfigXmlUrlString = getEnvironmentProperty("statistics.endpoint.logbackConfigXmlUrl");
+        }
+        return logbackConfigXmlUrlString;
     }
 }

--- a/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
+++ b/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/config.groovy
@@ -60,5 +60,13 @@ f.section(title:_("Statistics Gatherer")) {
         f.entry(title:_("Enable HTTP publishing?"), field:"shouldSendApiHttpRequests") {
             f.checkbox(default: instance.shouldSendApiHttpRequests == null ? false : instance.shouldSendApiHttpRequests.equals(true));
         }
+
+        f.entry(title:_("Enable publish of events to LOGBack"), field:"shouldSendToLogback") {
+            f.checkbox()
+        }
+
+        f.entry(title:_("LOGBack XML configuration URL"), field:"logbackConfigXmlUrl") {
+            f.textbox()
+        }
     }
 }

--- a/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/help-logbackConfigXmlUrl.html
+++ b/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/help-logbackConfigXmlUrl.html
@@ -1,0 +1,3 @@
+<div>
+    URL of the <a href="https://logback.qos.ch/manual/configuration.html" target="_blank">LOGBack XML</a> configuration file<br/>
+</div>

--- a/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/help-shouldSendToLogback.html
+++ b/src/main/resources/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration/help-shouldSendToLogback.html
@@ -1,0 +1,3 @@
+<div>
+    Allow to push events to a <a href="https://logback.qos.ch/manual/appenders.html"  target="_blank">LOGBack Appender</a><br/>
+</div>

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListenerTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListenerTest.java
@@ -4,6 +4,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.tasks.BuildStep;
 import org.jenkins.plugins.statistics.gatherer.model.step.BuildStepStats;
+import org.jenkins.plugins.statistics.gatherer.util.LogbackUtil;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
 import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
 import org.jenkins.plugins.statistics.gatherer.util.SnsClientUtil;
@@ -27,7 +28,7 @@ import static org.mockito.Matchers.anyString;
  */
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({PropertyLoader.class, RestClientUtil.class, SnsClientUtil.class})
+@PrepareForTest({PropertyLoader.class, RestClientUtil.class, SnsClientUtil.class, LogbackUtil.class})
 public class BuildStepStatsListenerTest {
 
     private BuildStepStatsListener listener;
@@ -57,7 +58,6 @@ public class BuildStepStatsListenerTest {
         BuildStepStats buildStepStats = buildStepStatsArgumentCaptor.getValue();
         assertEquals("aUrl", buildStepStats.getBuildUrl());
         assertEquals(new Date(0), buildStepStats.getEndTime());
-
     }
 
     @Test

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListenerTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListenerTest.java
@@ -1,0 +1,86 @@
+package org.jenkins.plugins.statistics.gatherer.listeners;
+
+import hudson.model.FreeStyleProject;
+import org.jenkins.plugins.statistics.gatherer.model.job.JobStats;
+import org.jenkins.plugins.statistics.gatherer.util.LogbackUtil;
+import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
+import org.jenkins.plugins.statistics.gatherer.util.RestClientUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.ArgumentCaptor;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PropertyLoader.class, RestClientUtil.class, LogbackUtil.class})
+@PowerMockIgnore({"javax.crypto.*"})
+public class ItemStatsListenerTest {
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    private ItemStatsListener listener;
+
+    @Before
+    public void setup() {
+        listener = new ItemStatsListener();
+        mockStatic(PropertyLoader.class);
+    }
+
+    @Test
+    public void whenItemCredated_thenPost() throws Exception {
+        mockStatic(RestClientUtil.class);
+        when(PropertyLoader.getProjectInfo()).thenReturn(true);
+
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+
+        verifyStatic();
+        ArgumentCaptor<JobStats> captor =
+                ArgumentCaptor.forClass(JobStats.class);
+        RestClientUtil.postToService(anyString(), captor.capture());
+        JobStats jobStats = captor.getValue();
+
+        assertThat(jobStats.getName(), startsWith("test"));
+        assertThat(jobStats.getJobUrl(), startsWith("job/test"));
+        assertThat(jobStats.getStatus(), equalTo("ACTIVE"));
+    }
+
+    @Test
+    public void whenItemDeleted_thenPost() throws Exception {
+        mockStatic(RestClientUtil.class);
+        when(PropertyLoader.getProjectInfo()).thenReturn(true);
+
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+        project.delete();
+
+        verifyStatic(times(3));
+        ArgumentCaptor<JobStats> captor =
+                ArgumentCaptor.forClass(JobStats.class);
+        RestClientUtil.postToService(anyString(), captor.capture());
+        List<JobStats> jobStats = captor.getAllValues();
+
+        JobStats disabled = jobStats.get(1);
+        JobStats deleted = jobStats.get(2);
+
+        assertThat(disabled.getName(), startsWith("test"));
+        assertThat(disabled.getJobUrl(), startsWith("job/test"));
+        assertThat(disabled.getStatus(), equalTo("DISABLED"));
+
+        assertThat(deleted.getName(), startsWith("test"));
+        assertThat(deleted.getJobUrl(), startsWith("job/test"));
+        assertThat(deleted.getStatus(), equalTo("DELETED"));
+    }
+}


### PR DESCRIPTION
Add optional support for sending events to NATS
by using a LOGBack appender

Requires as an optional dependency the installation of logback-nats-appender plugin.