### PR TITLE
Disable HTTP log notification by default

### DIFF
--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoader.java
@@ -10,6 +10,7 @@ import jenkins.model.Jenkins;
 import org.jenkins.plugins.statistics.gatherer.StatisticsConfiguration;
 
 import java.util.List;
+import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
 
@@ -35,7 +36,11 @@ public class PropertyLoader {
     }
 
     protected String getResourceBundleProperty(String keyProperty) {
-        return resourceBundle.getString(keyProperty);
+        try {
+            return resourceBundle.getString(keyProperty);
+        } catch (MissingResourceException e) {
+            return null;
+        }
     }
 
     public String getProperty(

--- a/src/main/resources/statistics.properties
+++ b/src/main/resources/statistics.properties
@@ -1,13 +1,8 @@
-statistics.endpoint.queueUrl=http://ci.mycompany.com/api/queue
-statistics.endpoint.buildUrl=http://ci.mycompany.com/api/build
-statistics.endpoint.projectUrl=http://cistats.mycompany.com/api/projects
-statistics.endpoint.buildStepUrl=http://ci.mycompany.com/api/step
-statistics.endpoint.scmCheckoutUrl=http://ci.mycompany.com/api/scm
 statistics.endpoint.queueInfo=true
 statistics.endpoint.buildInfo=true
 statistics.endpoint.projectInfo=true
 statistics.endpoint.buildStepInfo=true
 statistics.endpoint.scmCheckoutInfo=true
 statistics.endpoint.awsRegion=us-east-1
-statistics.endpoint.shouldSendApiHttpRequests=true
+statistics.endpoint.shouldSendApiHttpRequests=false
 statistics.endpoint.shouldPublishToAwsSnsQueue=false

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoaderTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/util/PropertyLoaderTest.java
@@ -61,6 +61,15 @@ public class PropertyLoaderTest {
     }
 
     @Test
+    public void givenResourceBundleWithoutProperty_whenGetKey_thenReturnNull(){
+        //given
+        //when
+        String property = PropertyLoader.getInstance().getResourceBundleProperty("non.existent.property");
+        //then
+        assertNull("Non existent properties should return null values", property);
+    }
+
+    @Test
     public void givenQueueUrl_whenGetQueueUrlEndpoint_thenReturnQueueUrl(){
         //given
         PowerMockito.mockStatic(StatisticsConfiguration.class);


### PR DESCRIPTION
When the plugin has just been installed, the URLs are empty
and HTTP notification should be disabled.

A failure in locating the configuration values shouldn't throw an
exception and just silently fallback to the other configuration values.

Change-Id: Ib5354c871e13023c24d94ee372c0bc4f67afd6cb