### PR TITLE
Make LOGBack implementation truly optional

### DIFF
--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/Logback.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/Logback.java
@@ -1,0 +1,22 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+/**
+ * Subsystem to send logs through LOGBack
+ */
+public interface Logback {
+
+    /**
+     * Define the LOGBack logger name to use
+     *
+     * @param loggerName the logger name to use
+     * @return this instance
+     */
+    Logback setLoggerName(String loggerName);
+
+    /**
+     * Send the message to LOGBack
+     *
+     * @param msg message to send to LOGBack
+     */
+    void log(String msg);
+}

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/LogbackFactory.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/LogbackFactory.java
@@ -1,0 +1,9 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+public class LogbackFactory {
+
+    public static Logback create(String loggerName) throws Exception {
+        Class<Logback> logback = (Class<Logback>) Class.forName(Logback.class.getName() + "Impl");
+        return logback.newInstance().setLoggerName(loggerName);
+    }
+}

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/util/LogbackImpl.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/util/LogbackImpl.java
@@ -1,0 +1,45 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.util.ContextInitializer;
+import ch.qos.logback.core.joran.spi.JoranException;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class LogbackImpl implements Logback {
+    private static Logger logger;
+
+    @Override
+    public Logback setLoggerName(String loggerName) {
+        LoggerContext loggerContext = new LoggerContext();
+        ContextInitializer contextInitializer = new ContextInitializer(loggerContext);
+        try {
+            String configurationUrlString = PropertyLoader.getLogbackConfigXmlUrl();
+            if (configurationUrlString == null) {
+                throw new IllegalStateException("LOGBack XML configuration file not specified");
+            }
+
+            URL configurationUrl = new URL(configurationUrlString);
+            contextInitializer.configureByResource(configurationUrl);
+            logger = loggerContext.getLogger(loggerName);
+            return this;
+        } catch (JoranException e) {
+            throw new RuntimeException("Unable to configure logger", e);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Unable to find LOGBack XML configuration", e);
+        }
+    }
+
+    @Override
+    public void log(String msg) {
+        if (logger != null) {
+            logger.info(msg);
+        }
+    }
+
+    public Logger getLogger() {
+        return logger;
+    }
+}

--- a/src/main/resources/statistics.properties
+++ b/src/main/resources/statistics.properties
@@ -6,3 +6,4 @@ statistics.endpoint.scmCheckoutInfo=true
 statistics.endpoint.awsRegion=us-east-1
 statistics.endpoint.shouldSendApiHttpRequests=false
 statistics.endpoint.shouldPublishToAwsSnsQueue=false
+statistics.endpoint.shouldSendToLogback=false

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/util/LogbackImplTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/util/LogbackImplTest.java
@@ -1,0 +1,97 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+
+import hudson.Plugin;
+import jenkins.model.Jenkins;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.CoreMatchers.any;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNotNull;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PropertyLoader.class, Jenkins.class})
+public class LogbackImplTest {
+
+    @Mock
+    Jenkins jenkinsMock;
+
+    Path logbackXml;
+
+    @Before
+    public void setup() throws IOException {
+        mockStatic(PropertyLoader.class);
+        mockStatic(Jenkins.class);
+
+        logbackXml = Files.createTempFile(LogbackImplTest.class.getName(), ".xml");
+        Files.write(logbackXml, ("<configuration>\n" +
+                "\n" +
+                "  <appender name=\"STDOUT\" class=\"ch.qos.logback.core.ConsoleAppender\">\n" +
+                "    <!-- encoders are assigned the type\n" +
+                "         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->\n" +
+                "    <encoder>\n" +
+                "      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>\n" +
+                "    </encoder>\n" +
+                "  </appender>\n" +
+                "\n" +
+                "  <root level=\"debug\">\n" +
+                "    <appender-ref ref=\"STDOUT\" />\n" +
+                "  </root>\n" +
+                "</configuration>").getBytes());
+    }
+
+    @Test
+    public void givenLogbackAppender_whenLogbackIsConfigured_thenLoggerIsCreated() throws MalformedURLException {
+        when(PropertyLoader.getLogbackConfigXmlUrl()).thenReturn(logbackXml.toFile().toURI().toURL().toString());
+        when(PropertyLoader.getShouldSendToLogback()).thenReturn(true);
+        when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        Plugin pluginMock = mock(Plugin.class);
+        when(jenkinsMock.getPlugin(LogbackUtil.LOGBACK_PLUGIN_NAME)).thenReturn(pluginMock);
+
+
+        LogbackUtil logbackUtil = new LogbackUtil();
+        logbackUtil.logInfo("something");
+
+        Logback logback = logbackUtil.getLogback();
+        assertThat(logback, is(notNullValue()));
+        assertThat(logback.getClass().getName(), is(LogbackImpl.class.getName()));
+
+        LogbackImpl logbackImpl = ((LogbackImpl) logback);
+        assertThat(logbackImpl.getLogger(), is(notNullValue()));
+    }
+
+    @Test
+    public void givenLogbackAppender_whenLogbackIsEnabledButNotConfigured_thenLoggerIsNotCreated() throws MalformedURLException {
+        when(PropertyLoader.getLogbackConfigXmlUrl()).thenReturn("");
+        when(PropertyLoader.getShouldSendToLogback()).thenReturn(true);
+        when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        Plugin pluginMock = mock(Plugin.class);
+        when(jenkinsMock.getPlugin(LogbackUtil.LOGBACK_PLUGIN_NAME)).thenReturn(pluginMock);
+
+
+        LogbackUtil logbackUtil = new LogbackUtil();
+        logbackUtil.logInfo("something");
+
+        Logback logback = logbackUtil.getLogback();
+        assertThat(logback, is(nullValue()));
+    }
+
+
+}

--- a/src/test/java/org/jenkins/plugins/statistics/gatherer/util/LogbackUtilTest.java
+++ b/src/test/java/org/jenkins/plugins/statistics/gatherer/util/LogbackUtilTest.java
@@ -1,0 +1,54 @@
+package org.jenkins.plugins.statistics.gatherer.util;
+
+import hudson.Plugin;
+import jenkins.model.Jenkins;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Jenkins.class, LogbackFactory.class, PropertyLoader.class})
+public class LogbackUtilTest {
+
+    @Mock
+    Jenkins jenkinsMock;
+
+    @Mock
+    Logback logbackMock;
+
+    @Before
+    public void setup() throws Exception {
+        mockStatic(Jenkins.class);
+        mockStatic(LogbackFactory.class);
+        mockStatic(PropertyLoader.class);
+        when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+        when(PropertyLoader.getShouldSendToLogback()).thenReturn(true);
+        when(LogbackFactory.create(any(String.class))).thenReturn(logbackMock);
+    }
+
+    @Test
+    public void givenJenkinsWithoutLogback_whenLogging_thenDoNotCreateLogback() throws Exception {
+        when(jenkinsMock.getPlugin(LogbackUtil.LOGBACK_PLUGIN_NAME)).thenReturn(null);
+
+        new LogbackUtil().logInfo(new String("foo"));
+
+        verifyZeroInteractions(LogbackFactory.class);
+    }
+
+    @Test
+    public void givenJenkinsWithLogback_whenLogging_thenCreateLogback() throws Exception {
+        Plugin pluginMock = mock(Plugin.class);
+        when(jenkinsMock.getPlugin(LogbackUtil.LOGBACK_PLUGIN_NAME)).thenReturn(pluginMock);
+
+        new LogbackUtil().logInfo(new String("foo"));
+
+        verifyStatic(LogbackFactory.class);
+    }
+}


### PR DESCRIPTION
When there isn't a LOGBack support available, do not instantiate
and refer to any of the dependant classes so that nothing fails.

Change-Id: Ifed3aaacd22aa3f6f540c3ed407f05594131f32e