### PR TITLE
[JENKINS-51266] Mark all extensions as dynamically loadable

### DIFF
--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/StatisticsConfiguration.java
@@ -3,6 +3,7 @@ package org.jenkins.plugins.statistics.gatherer;
 import com.amazonaws.regions.Region;
 import hudson.Extension;
 import hudson.util.FormValidation;
+import jenkins.YesNoMaybe;
 import jenkins.model.GlobalConfiguration;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.QueryParameter;
@@ -12,7 +13,7 @@ import com.amazonaws.regions.RegionUtils;
 /**
  * Created by hthakkallapally on 6/25/2015.
  */
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 public class StatisticsConfiguration extends GlobalConfiguration {
 
     private static final String SLASH = "/";

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/BuildStepStatsListener.java
@@ -5,6 +5,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.BuildStepListener;
 import hudson.tasks.BuildStep;
+import jenkins.YesNoMaybe;
 import org.jenkins.plugins.statistics.gatherer.model.step.BuildStepStats;
 import org.jenkins.plugins.statistics.gatherer.util.LogbackUtil;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
@@ -16,7 +17,7 @@ import java.util.Date;
 /**
  * Created by mcharron on 2016-07-12.
  */
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 public class BuildStepStatsListener extends BuildStepListener {
 
     @Override

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ItemStatsListener.java
@@ -5,6 +5,7 @@ import hudson.model.AbstractProject;
 import hudson.model.Item;
 import hudson.model.User;
 import hudson.model.listeners.ItemListener;
+import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
 import org.jenkins.plugins.statistics.gatherer.model.job.JobStats;
 import org.jenkins.plugins.statistics.gatherer.util.*;
@@ -17,7 +18,7 @@ import java.util.logging.Logger;
 /**
  * Created by hthakkallapally on 3/12/2015.
  */
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 public class ItemStatsListener extends ItemListener {
     private static final Logger LOGGER = Logger.getLogger(ItemStatsListener.class.getName());
 

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/QueueStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/QueueStatsListener.java
@@ -6,6 +6,7 @@ import hudson.model.Queue.*;
 import hudson.model.queue.QueueListener;
 import hudson.triggers.SCMTrigger;
 import hudson.triggers.TimerTrigger;
+import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
 import org.jenkins.plugins.statistics.gatherer.model.queue.QueueCause;
 import org.jenkins.plugins.statistics.gatherer.model.queue.QueueStats;
@@ -19,7 +20,7 @@ import java.util.logging.Logger;
 /**
  * Created by hthakkallapally on 3/13/2015.
  */
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 public class QueueStatsListener extends QueueListener {
     private static final Logger LOGGER = Logger.getLogger(
             QueueStatsListener.class.getName());

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/RunStatsListener.java
@@ -8,6 +8,7 @@ import hudson.model.*;
 import hudson.model.listeners.RunListener;
 import hudson.triggers.SCMTrigger;
 import hudson.triggers.TimerTrigger;
+import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
 import org.jenkins.plugins.statistics.gatherer.model.build.BuildStats;
 import org.jenkins.plugins.statistics.gatherer.model.build.SCMInfo;
@@ -27,7 +28,7 @@ import java.util.logging.Logger;
  *
  * @author hthakkallapally
  */
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 public class RunStatsListener extends RunListener<Run<?, ?>> {
 
     private static final Logger LOGGER = Logger.getLogger(RunStatsListener.class.getName());

--- a/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/gatherer/listeners/ScmStatsListener.java
@@ -8,6 +8,7 @@ import hudson.model.TaskListener;
 import hudson.model.listeners.SCMListener;
 import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
+import jenkins.YesNoMaybe;
 import org.jenkins.plugins.statistics.gatherer.model.scm.ScmCheckoutInfo;
 import org.jenkins.plugins.statistics.gatherer.util.LogbackUtil;
 import org.jenkins.plugins.statistics.gatherer.util.PropertyLoader;
@@ -21,7 +22,7 @@ import java.util.Date;
 /**
  * Created by mcharron on 2016-07-15.
  */
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 public class ScmStatsListener extends SCMListener{
 
     @Override


### PR DESCRIPTION
There are no reasons why this plugin should require a Jenkins
restart. Mark all extensions as dynamically loadable
so that no restarts will be required when installing it.

Change-Id: I18b2264b44288b82b4985dff5a9a35ba8cfc09a4